### PR TITLE
Code cleanup - standardize __future__ import

### DIFF
--- a/aws_tools/dynamodb_handler.py
+++ b/aws_tools/dynamodb_handler.py
@@ -1,16 +1,5 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Richard Mahn <richard_mahn@wycliffeassociates.org>
-#
-#  DynamoDBHandler
-
+from __future__ import unicode_literals, print_function
 import boto3
-
 from six import iteritems
 from boto3 import Session
 from boto3.dynamodb.conditions import Attr, Key

--- a/aws_tools/lambda_handler.py
+++ b/aws_tools/lambda_handler.py
@@ -1,16 +1,8 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Richard Mahn <richard_mahn@wycliffeassociates.org>
-
+from __future__ import unicode_literals, print_function
 import json
 import boto3
-
 from boto3 import Session
+
 
 class LambdaHandler(object):
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):

--- a/aws_tools/s3_handler.py
+++ b/aws_tools/s3_handler.py
@@ -1,17 +1,8 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Richard Mahn <richard_mahn@wycliffeassociates.org>
-
+from __future__ import unicode_literals, print_function
 import os
 import json
 import boto3
 import botocore
-
 from boto3.session import Session
 from general_tools.file_utils import get_mime_type
 

--- a/door43_tools/manifest_handler.py
+++ b/door43_tools/manifest_handler.py
@@ -304,22 +304,22 @@ class Manifest(object):
     def get_resource_name(resource_id):
         resource_id = resource_id.lower()
         if resource_id == 'ulb':
-            return u'Unlocked Literal Bible'
+            return 'Unlocked Literal Bible'
         elif resource_id == 'udb':
-            return u'Unlocked Dynamic Bible'
+            return 'Unlocked Dynamic Bible'
         elif resource_id == 'bible':
-            return u'Bible'
+            return 'Bible'
         elif resource_id == 'obs':
-            return u'Open Bible Stories'
+            return 'Open Bible Stories'
         elif resource_id == 'tn':
-            return u'translationNotes'
+            return 'translationNotes'
         elif resource_id == 'tw':
-            return u'translationWords'
+            return 'translationWords'
         elif resource_id == 'tq':
-            return u'translationQuestions'
+            return 'translationQuestions'
         elif resource_id == 'ta':
-            return u'translationAcademy'
-        return u''
+            return 'translationAcademy'
+        return ''
 
 
 class MetaData(object):

--- a/door43_tools/preprocessors.py
+++ b/door43_tools/preprocessors.py
@@ -101,7 +101,7 @@ class TsObsMarkdownPreprocessor(ObsMarkdownPreprocessor):
             markdown = '# {0}\n\n'.format(chapter.get('title'))
             for frame in chapter.get('frames'):
                 markdown += '![Frame {0}](https://cdn.door43.org/obs/jpg/360px/obs-en-{0}.jpg)\n\n'.format(frame.get('id'))
-                markdown += frame.get('text')+u'\n\n'
+                markdown += frame.get('text')+'\n\n'
             markdown += '_{0}_\n'.format(chapter.get('reference'))
 
             output_file = os.path.join(self.output_dir, '{0}.md'.format(chapter.get('id')))

--- a/door43_tools/preprocessors.py
+++ b/door43_tools/preprocessors.py
@@ -98,11 +98,11 @@ class TsObsMarkdownPreprocessor(ObsMarkdownPreprocessor):
         chapters = self.get_chapters()
 
         for chapter in chapters:
-            markdown = u'# {0}\n\n'.format(chapter.get('title'))
+            markdown = '# {0}\n\n'.format(chapter.get('title'))
             for frame in chapter.get('frames'):
-                markdown += u'![Frame {0}](https://cdn.door43.org/obs/jpg/360px/obs-en-{0}.jpg)\n\n'.format(frame.get('id'))
+                markdown += '![Frame {0}](https://cdn.door43.org/obs/jpg/360px/obs-en-{0}.jpg)\n\n'.format(frame.get('id'))
                 markdown += frame.get('text')+u'\n\n'
-            markdown += u'_{0}_\n'.format(chapter.get('reference'))
+            markdown += '_{0}_\n'.format(chapter.get('reference'))
 
             output_file = os.path.join(self.output_dir, '{0}.md'.format(chapter.get('id')))
             write_file(output_file, markdown)
@@ -114,12 +114,12 @@ class TsBibleUsfmPreprocessor(UsfmPreprocessor):
         self.title = ''
 
     def get_usfm_header(self):
-        header = u'\\id {0} {1}\n'.format(self.manifest.project['id'].upper(), self.manifest.resource['name'])
-        header += u'\\ide UTF-8\n'
-        header += u'\\h {0}\n'.format(self.title)
-        header += u'\\toc1 {0}\n'.format(self.title)
-        header += u'\\toc2 {0}\n'.format(self.title)
-        header += u'\\mt {0}\n\n'.format(self.title)
+        header = '\\id {0} {1}\n'.format(self.manifest.project['id'].upper(), self.manifest.resource['name'])
+        header += '\\ide UTF-8\n'
+        header += '\\h {0}\n'.format(self.title)
+        header += '\\toc1 {0}\n'.format(self.title)
+        header += '\\toc2 {0}\n'.format(self.title)
+        header += '\\mt {0}\n\n'.format(self.title)
         return header
 
     def get_chapters(self):
@@ -135,8 +135,8 @@ class TsBibleUsfmPreprocessor(UsfmPreprocessor):
     def get_chapter(self, chapter):
         chapter_content = ''
         for chapter in sorted(chapter):
-            chapter_content += read_file(chapter) + u'\n'
-        return chapter_content + u'\n\n'
+            chapter_content += read_file(chapter) + '\n'
+        return chapter_content + '\n\n'
 
     # Get the title of the project
     def get_title(self):

--- a/door43_tools/project_deployer.py
+++ b/door43_tools/project_deployer.py
@@ -73,7 +73,7 @@ class ProjectDeployer(object):
         if len(html_files) < 1:
             content = ''
             if len(build_log['errors']) > 0:
-                content += u"""
+                content += """
                     <div style="text-align:center;margin-bottom:20px">
                         <i class="fa fa-times-circle-o" style="font-size: 250px;font-weight: 300;color: red"></i>
                         <br/>
@@ -83,7 +83,7 @@ class ProjectDeployer(object):
                 """
                 content += '<div><ul><li>' + '</li><li>'.join(build_log['errors']) + '</li></ul></div>'
             elif len(build_log['warnings']) > 0:
-                content += u"""
+                content += """
                     <div style="text-align:center;margin-bottom:20px">
                         <i class="fa fa-exclamation-circle" style="font-size: 250px;font-weight: 300;color: yellow"></i>
                         <br/>
@@ -96,7 +96,7 @@ class ProjectDeployer(object):
                 content += '<h1>{0}</h1>'.format(build_log['message'])
                 content += '<p><i>No content is available to show for {0} yet.</i></p>'.format(repo_name)
 
-            html = u"""
+            html = """
                 <html lang="en">
                     <head>
                         <title>{0}</title>'

--- a/general_tools/file_utils.py
+++ b/general_tools/file_utils.py
@@ -1,19 +1,9 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Phil Hopper <phillip_hopper@wycliffeassociates.org>
-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import codecs
 import json
 import os
 import zipfile
 import sys
-
 from mimetypes import MimeTypes
 
 # we need this to check for string versus object

--- a/general_tools/print_utils.py
+++ b/general_tools/print_utils.py
@@ -1,12 +1,3 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Phil Hopper <phillip_hopper@wycliffeassociates.org>
-
 from __future__ import print_function, unicode_literals
 
 # console codes

--- a/general_tools/smartquotes.py
+++ b/general_tools/smartquotes.py
@@ -16,7 +16,7 @@ def smartquotes(text):
     com = Popen(command, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     out, err = com.communicate(text.encode('utf-8'))
     com_out = out.decode('utf-8')
-    text = com_out.replace(u'\n', ' ').strip()
+    text = com_out.replace('\n', ' ').strip()
     return text
 
 

--- a/general_tools/smartquotes.py
+++ b/general_tools/smartquotes.py
@@ -1,19 +1,8 @@
-#!/usr/bin/env python2
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Jesse Griffin <jesse@distantshores.org>
-
 """
 This script accepts a paragraph of input and outputs typographically correct
 text using pandoc.  Note line breaks are not retained.
 """
-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import shlex
 from subprocess import *
 import sys

--- a/general_tools/smartquotes.py
+++ b/general_tools/smartquotes.py
@@ -16,7 +16,7 @@ def smartquotes(text):
     com = Popen(command, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     out, err = com.communicate(text.encode('utf-8'))
     com_out = out.decode('utf-8')
-    text = com_out.replace(u'\n', u' ').strip()
+    text = com_out.replace(u'\n', ' ').strip()
     return text
 
 

--- a/gogs_tools/gogs_handler.py
+++ b/gogs_tools/gogs_handler.py
@@ -1,12 +1,4 @@
-# -*- coding: utf8 -*-
-#
-#  Copyright (c) 2016 unfoldingWord
-#  http://creativecommons.org/licenses/MIT/
-#  See LICENSE file for details.
-#
-#  Contributors:
-#  Richard Mahn <richard_mahn@wycliffeassociates.org>
-
+from __future__ import unicode_literals, print_function
 from gogs_client import GogsApi
 from gogs_client import Token
 

--- a/manager/job.py
+++ b/manager/job.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 from six import string_types
 from object import TxObject
 

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 import json
 import hashlib
 import requests

--- a/manager/module.py
+++ b/manager/module.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 from six import string_types
 from object import TxObject
 

--- a/manager/object.py
+++ b/manager/object.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 from six import iteritems
 
 

--- a/tests/aws_tools_tests/test_dynamodb_handler.py
+++ b/tests/aws_tools_tests/test_dynamodb_handler.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import mock
 import unittest
 import aws_tools.dynamodb_handler

--- a/tests/aws_tools_tests/test_lambda_handler.py
+++ b/tests/aws_tools_tests/test_lambda_handler.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import mock
 import unittest
 import json

--- a/tests/aws_tools_tests/test_s3_handler.py
+++ b/tests/aws_tools_tests/test_s3_handler.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import unittest
 
 

--- a/tests/client_tests/test_client_tools.py
+++ b/tests/client_tests/test_client_tools.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import unittest
 
 

--- a/tests/door43_tools_tests/test_language_handler.py
+++ b/tests/door43_tools_tests/test_language_handler.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import unittest
 
 

--- a/tests/door43_tools_tests/test_manifest_handler.py
+++ b/tests/door43_tools_tests/test_manifest_handler.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals, print_function
 import unittest
 
 

--- a/tests/door43_tools_tests/test_obs_handler.py
+++ b/tests/door43_tools_tests/test_obs_handler.py
@@ -1,6 +1,6 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import os
 import unittest
-
 from door43_tools.obs_handler import OBSInspection
 
 
@@ -126,4 +126,3 @@ class TestObsHandler(unittest.TestCase):
     def verify_results(self, expected_errors, expected_warnings, inspection):
         self.assertEqual(len(inspection.logger.logs["warning"]) > 0, expected_warnings)
         self.assertEqual(len(inspection.logger.logs["error"]) > 0, expected_errors)
-

--- a/tests/general_tools_tests/test_file_utils.py
+++ b/tests/general_tools_tests/test_file_utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import json
 import os.path
 import shutil

--- a/tests/general_tools_tests/test_smartquotes.py
+++ b/tests/general_tools_tests/test_smartquotes.py
@@ -1,5 +1,5 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import unittest
-
 from general_tools import smartquotes
 
 

--- a/tests/general_tools_tests/test_url_utils.py
+++ b/tests/general_tools_tests/test_url_utils.py
@@ -1,8 +1,8 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import os
 import tempfile
 from six import BytesIO
 import unittest
-
 from general_tools import url_utils
 
 

--- a/tests/gogs_tools_tests/test_gogs_utils.py
+++ b/tests/gogs_tools_tests/test_gogs_utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import mock
 import unittest
 

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -1,9 +1,9 @@
+from __future__ import absolute_import, unicode_literals, print_function
 import itertools
 import unittest
 import mock
 import responses
 from six import StringIO
-
 from tests.manager_tests import mock_utils
 from manager.job import TxJob
 from manager.manager import TxManager

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -315,7 +315,7 @@ class ManagerTest(unittest.TestCase):
             self.assertIn("href", link_data)
             self.assertEqual(self.MOCK_API_URL + "/tx/job", link_data["href"])
             self.assertIn("rel", link_data)
-            self.assertIsInstance(link_data["rel"], str)
+            self.assertIsInstance(link_data["rel"], unicode)
             self.assertIn("method", link_data)
             self.assertIn(link_data["method"],
                           ["GET", "POST", "PUT", "PATCH", "DELETE"])


### PR DESCRIPTION
Just standardized all headers of .py files, to have proper __future__ imports (absolute_import was added to work with PyCharm unit testing)

Relates to https://github.com/unfoldingWord-dev/door43.org/issues/412