### PR TITLE
Fix inheritance in Handler class

### DIFF
--- a/lambda_handlers/client_callback_handler.py
+++ b/lambda_handlers/client_callback_handler.py
@@ -5,7 +5,7 @@ from client.client_callback import ClientCallback
 
 class ClientCallbackHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/client_webhook_handler.py
+++ b/lambda_handlers/client_webhook_handler.py
@@ -5,7 +5,7 @@ from client.client_webhook import ClientWebhook
 
 class ClientWebhookHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/convert_handler.py
+++ b/lambda_handlers/convert_handler.py
@@ -17,7 +17,7 @@ class ConvertHandler(Handler):
             self.converter_class = args.pop()
         Handler.__init__(self, *args, **kwargs)
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/door43_deploy_handler.py
+++ b/lambda_handlers/door43_deploy_handler.py
@@ -5,7 +5,7 @@ from lambda_handlers.handler import Handler
 
 class Door43DeployHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/handler.py
+++ b/lambda_handlers/handler.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals, print_function
+from abc import ABCMeta, abstractmethod
 
 
 class Handler(object):
+    __metaclass__ = ABCMeta
 
     def handle(self, event, context):
         """
@@ -10,19 +12,20 @@ class Handler(object):
         :return dict:
         """
         try:
-            return self.__handle(event, context)
+            return self._handle(event, context)
         except Exception as e:
             e.message = 'Bad Request: {0}'.format(e.message)
             raise e
 
-    def __handle(self, event, context):
+    @abstractmethod
+    def _handle(self, event, context):
         """
         Dummy function for handlers. Override this so handle() will catch the exception and make it a "Bad Request: "
         :param dict event:
         :param context:
         :return dict:
         """
-        pass
+        raise NotImplementedError()
 
     @staticmethod
     def retrieve(dictionary, key, dict_name=None):

--- a/lambda_handlers/list_endpoints_handler.py
+++ b/lambda_handlers/list_endpoints_handler.py
@@ -5,7 +5,7 @@ from lambda_handlers.handler import Handler
 
 class ListEndpointsHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/register_module_handler.py
+++ b/lambda_handlers/register_module_handler.py
@@ -5,7 +5,7 @@ from lambda_handlers.handler import Handler
 
 class RegisterModuleHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/request_job_handler.py
+++ b/lambda_handlers/request_job_handler.py
@@ -5,7 +5,7 @@ from lambda_handlers.handler import Handler
 
 class RequestJobHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/lambda_handlers/start_job_handler.py
+++ b/lambda_handlers/start_job_handler.py
@@ -5,7 +5,7 @@ from lambda_handlers.handler import Handler
 
 class StartJobHandler(Handler):
 
-    def __handle(self, event, context):
+    def _handle(self, event, context):
         """
         :param dict event:
         :param context:

--- a/tests/lambda_handlers_tests/test_handler.py
+++ b/tests/lambda_handlers_tests/test_handler.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals, print_function
+from unittest import TestCase
+from mock import patch
+from lambda_handlers.handler import Handler
+
+
+class MockHandler(Handler):
+
+    def _handle(self, event, context):
+        """
+        Test if this method is called
+        :param event:
+        :param context:
+        :return:
+        """
+        pass
+
+
+class TestHandler(TestCase):
+
+    def test_inheritance(self):
+        """
+        This tests if the inheritance from Handler is working correctly
+        :return: None
+        """
+
+        event = {'key1': 'value1'}
+        context = {'key2': 'value2'}
+
+        handler = MockHandler()
+
+        # noinspection PyUnresolvedReferences
+        with patch.object(handler, '_handle') as mock:
+            handler.handle(event, context)
+
+        mock.assert_called_with(event, context)


### PR DESCRIPTION
Fixes https://github.com/unfoldingWord-dev/door43.org/issues/436

Double underscores in the `__handle` method were the main problem.

Also made `Handler` an Abstract Base Class, and `_handle` and abstract method.