### PR TITLE
Splits the request_job_handler.py into two handlers

### DIFF
--- a/lambda_handlers/list_jobs_handler.py
+++ b/lambda_handlers/list_jobs_handler.py
@@ -3,7 +3,7 @@ from manager.manager import TxManager
 from lambda_handlers.handler import Handler
 
 
-class RequestJobHandler(Handler):
+class ListJobsHandler(Handler):
 
     def _handle(self, event, context):
         """
@@ -19,9 +19,6 @@ class RequestJobHandler(Handler):
             data.update(event['body-json'])
         # Set required env_vars
         env_vars = {
-            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
-            'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
-            'cdn_bucket': self.retrieve(event['vars'], 'cdn_bucket', 'Environment Vars'),
             'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars')
         }
-        return TxManager(**env_vars).setup_job(data)
+        return TxManager(**env_vars).list_jobs(data)

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -29,26 +29,33 @@ class TxManager(object):
         :param string module_table_name:
         """
         self.api_url = api_url
+        self.gogs_url = gogs_url
         self.cdn_url = cdn_url
         self.cdn_bucket = cdn_bucket
         self.quiet = quiet
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
+        self.job_table_name = job_table_name
+        self.module_table_name = module_table_name
+
+        if not self.job_table_name:
+            self.job_table_name = TxManager.JOB_TABLE_NAME
+        if not self.module_table_name:
+            self.module_table_name = TxManager.MODULE_TABLE_NAME
 
         self.job_db_handler = None
         self.module_db_handler = None
         self.gogs_handler = None
 
-        if not job_table_name:
-            job_table_name = self.JOB_TABLE_NAME
-        if not module_table_name:
-            module_table_name = self.MODULE_TABLE_NAME
+        self.setup_resources()
 
-        self.job_db_handler = DynamoDBHandler(job_table_name)
-        self.module_db_handler = DynamoDBHandler(module_table_name)
-
-        if gogs_url:
-            self.gogs_handler = GogsHandler(gogs_url)
+    def setup_resources(self):
+        if self.job_table_name:
+            self.job_db_handler = DynamoDBHandler(self.job_table_name)
+        if self.module_table_name:
+            self.module_db_handler = DynamoDBHandler(self.module_table_name)
+        if self.gogs_url:
+            self.gogs_handler = GogsHandler(self.gogs_url)
 
     def debug_print(self, message):
         if not self.quiet:

--- a/tests/lambda_handlers_tests/test_convertHandler.py
+++ b/tests/lambda_handlers_tests/test_convertHandler.py
@@ -8,8 +8,8 @@ from converters.usfm2html_converter import Usfm2HtmlConverter
 
 class TestConvertHandler(TestCase):
     @mock.patch('converters.converter.Converter.run')
-    def test_handle_for_obs(self, mock_convert_run_return_value):
-        mock_convert_run_return_value.return_value = None
+    def test_handle_for_obs(self, mock_convert_run):
+        mock_convert_run.return_value = None
         event = {
             'data': {
                 'job': {
@@ -18,78 +18,73 @@ class TestConvertHandler(TestCase):
                     'message': 'Conversion started...',
                     'started_at': '2017-03-08T18:57:53Z',
                     'errors': [],
-                    'job_id': 'a07116859e82e4596798cf81349a445e3dcecef463913f762cc5210aebe93db0',
+                    'job_id': '1234587890',
                     'method': 'GET',
-                    'source': 'https://s3-us-west-2.amazonaws.com/test-tx-webhook/preconvert/705948ab00.zip',
+                    'source': 'https://cdn.example.com/preconvert/705948ab00.zip',
                     'status': 'started',
                     'warnings': [],
                     'output_format': 'html',
                     'expires_at': '2017-03-09T18:57:51Z',
-                    'user': 'txwebhook',
-                    'cdn_file': 'tx/job/a07116859e82e4596798cf81349a445e3dcecef463913f762cc5210aebe93db0.zip',
-                    'cdn_bucket': 'test-cdn.door43.org',
+                    'user': 'exampleuser',
+                    'cdn_file': 'tx/job/1234567890.zip',
+                    'cdn_bucket': 'test_cdn_bucket',
                     'ended_at': None,
                     'success': None,
                     'created_at': '2017-03-08T18:57:51Z',
-                    'callback': 'https://test-api.door43.org/client/callback',
+                    'callback': 'https://api.example.com/client/callback',
                     'eta': '2017-03-08T18:58:11Z',
-                    'output': 'https://test-cdn.door43.org/tx/job/a07116859e82e4596798cf81349a445e3dcecef463913f762cc5210aebe93db0.zip',
+                    'output': 'https://cdn.example.com/tx/job/a07116859e82e4596798cf81349a445e3dcecef463913f762cc5210aebe93db0.zip',
                     'identifier': 'richmahn/en-obs/705948ab00',
                     'resource_type': 'obs'
                 }
             },
             'vars': {
-                'cdn_url': 'https://test-cdn.door43.org',
-                'api_url': 'https://test-api.door43.org',
-                'gogs_url': 'http://test.door43.org:3000',
-                'cdn_bucket': 'test-cdn.door43.org'
+                'cdn_url': 'https://cdn.exmaple.com',
+                'api_url': 'https://api.example.com',
+                'gogs_url': 'http://git.example.com',
+                'cdn_bucket': 'cdn_test_bucket'
             }
         }
         self.assertIsNone(ConvertHandler(Md2HtmlConverter).handle(event, None))
 
     @mock.patch('converters.converter.Converter.run')
-    def test_handle_for_usfm(self, mock_convert_run_return_value):
-        mock_convert_run_return_value.return_value = None
+    def test_handle_for_usfm(self, mock_convert_run):
+        mock_convert_run.return_value = None
         event = {
             'data': {
-                "job": 
-                    {
-                        "input_format": "usfm", 
-                        "convert_module": "usfm2html", 
-                        "message": "Conversion started...", 
-                        "started_at": "2017-03-15T17:50:14Z", 
-                        "errors": [], 
-                        "job_id": "b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310", 
-                        "links": {
-                            "href": "https://test-api.door43.org/tx/job/b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310",
-                            "method": "GET",
-                            "rel": "self"
-                        },
-                        "source": "https://s3-us-west-2.amazonaws.com/test-tx-webhook/preconvert/acf4d7eaf4.zip",
-                        "status": "started",
-                        "warnings": [],
-                        "output_format": "html",
-                        "expires_at": "2017-03-16T17:50:13Z",
-                        "user": "api_user",
-                        "cdn_file": "tx/job/b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310.zip",
-                        "cdn_bucket": "test-cdn.door43.org",
-                        "log": ["Started job b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310 at 2017-03-15T17:50:14Z",
-                        "Telling module usfm2html to convert https://s3-us-west-2.amazonaws.com/test-tx-webhook/preconvert/acf4d7eaf4.zip and put at https://test-cdn.door43.org/tx/job/b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310.zip"],
-                        "ended_at": None,
-                        "success": None,
-                        "created_at": "2017-03-15T17:50:13Z",
-                        "callback": "https://test-api.door43.org/client/callback",
-                        "eta": "2017-03-15T17:50:33Z",
-                        "output": "https://test-cdn.door43.org/tx/job/b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310.zip",
-                        "identifier": "richmahn/ulb_ne/acf4d7eaf4",
-                        "resource_type": "ulb"
-                    }
+                'job': {
+                    "input_format": "usfm",
+                    "convert_module": "usfm2html",
+                    'message': 'Conversion started...',
+                    'started_at': '2017-03-08T18:57:53Z',
+                    'errors': [],
+                    'job_id': '1234587890',
+                    'method': 'GET',
+                    'source': 'https://cdn.example.com/preconvert/705948ab00.zip',
+                    'status': 'started',
+                    'warnings': [],
+                    'output_format': 'html',
+                    'expires_at': '2017-03-09T18:57:51Z',
+                    'user': 'exampleuser',
+                    'cdn_file': 'tx/job/1234567890.zip',
+                    'cdn_bucket': 'test_cdn_bucket',
+                    "log": ["Started job b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310 at 2017-03-15T17:50:14Z",
+                            "Telling module usfm2html to convert https://s3-us-west-2.amazonaws.com/test-tx-webhook/preconvert/acf4d7eaf4.zip and put at https://test-cdn.door43.org/tx/job/b07f65d8be71fef116841e5161f3d7f9b69b83673bf72527f1d93186d8869310.zip"],
+                    'ended_at': None,
+                    'success': None,
+                    'created_at': '2017-03-08T18:57:51Z',
+                    'callback': 'https://api.example.com/client/callback',
+                    'eta': '2017-03-08T18:58:11Z',
+                    'output': 'https://cdn.example.com/tx/job/a07116859e82e4596798cf81349a445e3dcecef463913f762cc5210aebe93db0.zip',
+                    'identifier': 'richmahn/en-obs/705948ab00',
+                    'resource_type': 'obs'
+                }
             },
             'vars': {
-                'cdn_url': 'https://test-cdn.door43.org',
-                'api_url': 'https://test-api.door43.org',
-                'gogs_url': 'http://test.door43.org:3000',
-                'cdn_bucket': 'test-cdn.door43.org'
+                'cdn_url': 'https://cdn.exmaple.com',
+                'api_url': 'https://api.example.com',
+                'gogs_url': 'http://git.example.com',
+                'cdn_bucket': 'cdn_test_bucket'
             }
         }
         self.assertIsNone(ConvertHandler(Usfm2HtmlConverter).handle(event, None))

--- a/tests/lambda_handlers_tests/test_listJobsHandler.py
+++ b/tests/lambda_handlers_tests/test_listJobsHandler.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, unicode_literals, print_function
+import mock
+from unittest import TestCase
+from lambda_handlers.list_jobs_handler import ListJobsHandler
+
+
+class TestListJobsHandler(TestCase):
+
+    @mock.patch('manager.manager.TxManager.setup_resources')
+    @mock.patch('manager.manager.TxManager.list_jobs')
+    def test_handle(self, mock_setup_resources, mock_list_jobs):
+        mock_setup_resources.return_value = None
+        mock_list_jobs.return_value = None
+        event = {
+            'data': {
+                'gogs_user_token': 'token1',
+                'job_id': '1'
+            },
+            'vars': {
+                'gogs_url': 'https://git.example.com',
+                'cdn_url': 'https://cdn.exmaple.com',
+                'api_url': 'https://api.example.com',
+                'cdn_bucket': 'cdn_test_bucket'
+            }
+        }
+        handler = ListJobsHandler()
+        self.assertIsNone(handler.handle(event, None))


### PR DESCRIPTION
Fixes Issue #495, https://github.com/unfoldingWord-dev/door43.org/issues/495 on the tx-manager side. Splits the request_job_handler.py into two handers: list_jobs and request_job. This makes it clearer what is going on when someone just wants to get information on a job. Before it request_job had to figure out if it was an existing job or a new job. Now they are separate and pointed to separately in the API Gateway.