### PR TITLE
Separates resource creation in s3_handler's init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
   - '2.7'
 
+before install:
+  - eval export AWS_ACCESS_KEY_ID=\$${TRAVIS_BRANCH}_AWS_ACCESS_KEY_ID
+  - eval export AWS_SECRET_ACCESS_KEY=\$${TRAVIS_BRANCH}_AWS_SECRET_ACCESS_KEY
+  - eval export AWS_REGION=\$${TRAVIS_BRANCH}_AWS_REGION
+
 install:
   - pip install -r requirements.txt
   - pip install coveralls

--- a/tests/aws_tools_tests/test_s3_handler.py
+++ b/tests/aws_tools_tests/test_s3_handler.py
@@ -1,6 +1,21 @@
 from __future__ import absolute_import, unicode_literals, print_function
+import os
+import shutil
+import tempfile
 import unittest
+from unittest import TestCase
+from aws_tools.s3_handler import S3Handler
 
 
-class S3HandlerTests(unittest.TestCase):
-    pass
+class S3HandlerTests(TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix='s3HandlerTest_')
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir+'asdfa', ignore_errors=True)
+
+    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")
+    def test_download_dir(self):
+        handler = S3Handler(bucket_name='test-tx-manager')
+        handler.download_dir('test-s3-handler-download-dir', self.temp_dir)
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_dir, 'test-s3-handler-download-dir', 'test.json')))


### PR DESCRIPTION
Adds a setup_resources() called by s3_handler.py's `__init__()` function so that it can be mocked if needed.