### PR TITLE
Do not throw exception if a value in data is not an attribute

### DIFF
--- a/manager/object.py
+++ b/manager/object.py
@@ -13,9 +13,8 @@ class TxObject(object):
 
     def populate(self, data):
         for key, value in iteritems(data):
-            if not hasattr(self, key):
-                raise Exception('Invalid field given: {0}'.format(key))
-            setattr(self, key, value)
+            if hasattr(self, key):
+                setattr(self, key, value)
 
     def get_db_data(self):
         data = {}

--- a/tests/manager_tests/test_object.py
+++ b/tests/manager_tests/test_object.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, unicode_literals, print_function
+import unittest
+from manager.module import TxObject
+
+
+class MyObject(TxObject):
+    db_fields = [
+        'field1',
+        'field2'
+    ]
+
+    def __init__(self, quiet=False):
+        self.field1 = None
+        self.field2 = None
+        super(MyObject, self).__init__(quiet)
+
+
+class ObjectTest(unittest.TestCase):
+
+    def test_populate(self):
+        """
+        Test populate method
+        """
+        obj = MyObject()
+        data = {
+            'field1': 'value1',
+            'field2': 'value2',
+            'field3': 'value3'
+        }
+        obj.populate(data)
+        self.assertTrue(hasattr(obj, 'field1'))
+        self.assertEqual(obj.field2, 'value2')
+        self.assertFalse(hasattr(obj, 'field3'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We don't want this to throw an exception if a field from the data (which is from the DB) is not in the object's attributes so that we can have fields in the DB that the object doesn't need to know about (stats, etc.)