### PR TITLE
Feature - Issue #504 - Makes table names a part of environment variables

### DIFF
--- a/lambda_handlers/dashboard_handler.py
+++ b/lambda_handlers/dashboard_handler.py
@@ -17,7 +17,5 @@ class DashboardHandler(Handler):
         if 'body-json' in event and isinstance(event['body-json'], dict):
             data.update(event['body-json'])
         # Set required env_vars
-        env_vars = {
-            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars')
-        }
+        env_vars = {}
         return TxManager(**env_vars).generate_dashboard()

--- a/lambda_handlers/list_endpoints_handler.py
+++ b/lambda_handlers/list_endpoints_handler.py
@@ -19,6 +19,10 @@ class ListEndpointsHandler(Handler):
             data.update(event['body-json'])
         # Set required env_vars
         env_vars = {
-            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars')
+            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
+            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars'),
+            'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
+            'job_table_name': self.retrieve(event['vars'], 'job_table_name', 'Environment Vars'),
+            'module_table_name': self.retrieve(event['vars'], 'module_table_name', 'Environment Vars')
         }
         return TxManager(**env_vars).list_endpoints()

--- a/lambda_handlers/list_jobs_handler.py
+++ b/lambda_handlers/list_jobs_handler.py
@@ -19,6 +19,10 @@ class ListJobsHandler(Handler):
             data.update(event['body-json'])
         # Set required env_vars
         env_vars = {
-            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars')
+            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
+            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars'),
+            'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
+            'job_table_name': self.retrieve(event['vars'], 'job_table_name', 'Environment Vars'),
+            'module_table_name': self.retrieve(event['vars'], 'module_table_name', 'Environment Vars')
         }
         return TxManager(**env_vars).list_jobs(data)

--- a/lambda_handlers/register_module_handler.py
+++ b/lambda_handlers/register_module_handler.py
@@ -19,6 +19,10 @@ class RegisterModuleHandler(Handler):
             data.update(event['body-json'])
         # Set required env_vars
         env_vars = {
-            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars')
+            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
+            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars'),
+            'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
+            'job_table_name': self.retrieve(event['vars'], 'job_table_name', 'Environment Vars'),
+            'module_table_name': self.retrieve(event['vars'], 'module_table_name', 'Environment Vars')
         }
         return TxManager(**env_vars).register_module(data)

--- a/lambda_handlers/request_job_handler.py
+++ b/lambda_handlers/request_job_handler.py
@@ -20,8 +20,10 @@ class RequestJobHandler(Handler):
         # Set required env_vars
         env_vars = {
             'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
+            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars'),
             'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
-            'cdn_bucket': self.retrieve(event['vars'], 'cdn_bucket', 'Environment Vars'),
-            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars')
+            'job_table_name': self.retrieve(event['vars'], 'job_table_name', 'Environment Vars'),
+            'module_table_name': self.retrieve(event['vars'], 'module_table_name', 'Environment Vars'),
+            'cdn_bucket': self.retrieve(event['vars'], 'cdn_bucket', 'Environment Vars')
         }
         return TxManager(**env_vars).setup_job(data)

--- a/lambda_handlers/start_job_handler.py
+++ b/lambda_handlers/start_job_handler.py
@@ -12,5 +12,8 @@ class StartJobHandler(Handler):
         """
         for record in event['Records']:
             if record['eventName'] == 'INSERT' and 'job_id' in record['dynamodb']['Keys']:
+                ddbARN = record['eventSourceARN']
+                ddbTable = ddbARN.split(':')[5].split('/')[1]
+                env_vars = {'job_table_name': ddbTable}
                 job_id = record['dynamodb']['Keys']['job_id']['S']
-                TxManager().start_job(job_id)
+                TxManager(**env_vars).start_job(job_id)

--- a/tests/lambda_handlers_tests/test_listEndpointsHandler.py
+++ b/tests/lambda_handlers_tests/test_listEndpointsHandler.py
@@ -17,7 +17,9 @@ class TestListEndpointsHandler(TestCase):
                 'gogs_url': 'https://git.example.com',
                 'cdn_url': 'https://cdn.exmaple.com',
                 'api_url': 'https://api.example.com',
-                'cdn_bucket': 'cdn_test_bucket'
+                'cdn_bucket': 'cdn_test_bucket',
+                'job_table_name': 'test-tx-job',
+                'module_table_name': 'test-tx-module'
             }
         }
         handler = ListEndpointsHandler()

--- a/tests/lambda_handlers_tests/test_listJobsHandler.py
+++ b/tests/lambda_handlers_tests/test_listJobsHandler.py
@@ -20,7 +20,9 @@ class TestListJobsHandler(TestCase):
                 'gogs_url': 'https://git.example.com',
                 'cdn_url': 'https://cdn.exmaple.com',
                 'api_url': 'https://api.example.com',
-                'cdn_bucket': 'cdn_test_bucket'
+                'cdn_bucket': 'cdn_test_bucket',
+                'job_table_name': 'test-tx-job',
+                'module_table_name': 'test-tx-module'
             }
         }
         handler = ListJobsHandler()

--- a/tests/lambda_handlers_tests/test_registerModuleHandler.py
+++ b/tests/lambda_handlers_tests/test_registerModuleHandler.py
@@ -27,7 +27,9 @@ class TestRegisterModuleHandler(TestCase):
                 'gogs_url': 'https://git.example.com',
                 'cdn_url': 'https://cdn.exmaple.com',
                 'api_url': 'https://api.example.com',
-                'cdn_bucket': 'cdn_test_bucket'
+                'cdn_bucket': 'cdn_test_bucket',
+                'job_table_name': 'test-tx-job',
+                'module_table_name': 'test-tx-module'
             }
         }
         handler = RegisterModuleHandler()

--- a/tests/lambda_handlers_tests/test_requestJobHandler.py
+++ b/tests/lambda_handlers_tests/test_requestJobHandler.py
@@ -24,7 +24,9 @@ class TestRequestJobHandler(TestCase):
                 'gogs_url': 'https://git.example.com',
                 'cdn_url': 'https://cdn.exmaple.com',
                 'api_url': 'https://api.example.com',
-                'cdn_bucket': 'cdn_test_bucket'
+                'cdn_bucket': 'cdn_test_bucket',
+                'job_table_name': 'test-tx-job',
+                'module_table_name': 'test-tx-module'
             }
         }
         handler = RequestJobHandler()

--- a/tests/lambda_handlers_tests/test_startJobHandler.py
+++ b/tests/lambda_handlers_tests/test_startJobHandler.py
@@ -14,6 +14,7 @@ class TestStartJobHandler(TestCase):
             'Records': [
                 {
                     'eventName': 'INSERT',
+                    'eventSourceARN': 'arn:aws:dynamodb:us-west-2:111111111111:table/tx-job/stream/2020-10-10T08:18:22.385',
                     'dynamodb': {
                         'Keys': {'job_id':{'S': '1234'}}
                     }

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -13,13 +13,26 @@ from manager.module import TxModule
 
 class ManagerTest(unittest.TestCase):
     MOCK_API_URL = "https://api.example.com"
+    MOCK_CDN_URL = "https://cdn.example.com"
     MOCK_CALLBACK_URL = "https://callback.example.com/"
     MOCK_GOGS_URL = "https://mock.gogs.io"
+    MOCK_CDN_BUCKET = 'mock_bucket'
+    MOCK_JOB_TABLE_NAME = 'mock-job'
+    MOCK_MODULE_TABLE_NAME = 'mock-module'
 
     mock_job_db = None
     mock_module_db = None
     mock_db = None
     mock_gogs = None
+    
+    tx_manager_env_vars = {
+        'api_url': MOCK_API_URL,
+        'cdn_url': MOCK_CDN_URL,
+        'gogs_url': MOCK_GOGS_URL,
+        'cdn_bucket': MOCK_CDN_BUCKET,
+        'job_table_name': MOCK_JOB_TABLE_NAME,
+        'module_table_name': MOCK_MODULE_TABLE_NAME
+    }
 
     patches = []
     requested_urls = []
@@ -132,7 +145,7 @@ class ManagerTest(unittest.TestCase):
         """
         Successful call of setup_job
         """
-        tx_manager = TxManager(gogs_url=self.MOCK_GOGS_URL, cdn_bucket="test_bucket")
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         data = {
             "gogs_user_token": "token1",
             "cdn_bucket":  "test_cdn_bucket",
@@ -154,7 +167,8 @@ class ManagerTest(unittest.TestCase):
         """
         Tests bad calls of setup_job due to missing or bad input
         """
-        tx_manager = TxManager(gogs_url=self.MOCK_GOGS_URL)
+        tx_manager = TxManager(**self.tx_manager_env_vars)
+        tx_manager.cdn_bucket = None
 
         # Missing gogs_user_token
         data = {
@@ -198,7 +212,7 @@ class ManagerTest(unittest.TestCase):
         self.assertRaises(Exception, tx_manager.setup_job, data)
 
         # Missing resource_type
-        tx_manager = TxManager(gogs_url=self.MOCK_GOGS_URL)
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         data = {
             "gogs_user_token": "token1",
             "cdn_bucket":  "test_cdn_bucket",
@@ -255,7 +269,7 @@ class ManagerTest(unittest.TestCase):
         """
         Call setup_job when there is no applicable converter.
         """
-        tx_manager = TxManager()
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         data = {
             "gogs_user_token": "token1",
             "cdn_bucket": "test_cdn_bucket",
@@ -283,7 +297,7 @@ class ManagerTest(unittest.TestCase):
             }
         }, 200)
 
-        tx_manager = TxManager()
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         tx_manager.start_job(1)
 
         # job1's entry in database should have been updated
@@ -315,7 +329,7 @@ class ManagerTest(unittest.TestCase):
                 "message": "All good"
             }
         }, 200)
-        tx_manager = TxManager()
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         tx_manager.start_job(2)
 
         # job2's entry in database should have been updated
@@ -348,7 +362,7 @@ class ManagerTest(unittest.TestCase):
             }
         }, 200)
 
-        manager = TxManager()
+        manager = TxManager(**self.tx_manager_env_vars)
         manager.start_job(3)
 
         # job3's entry in database should have been updated
@@ -367,7 +381,7 @@ class ManagerTest(unittest.TestCase):
         """
         Call start_job with non-runnable/non-existent jobs
         """
-        tx_manager = TxManager()
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         ret0 = tx_manager.start_job(0)
         ret4 = tx_manager.start_job(4)
         ret5 = tx_manager.start_job(5)
@@ -392,11 +406,11 @@ class ManagerTest(unittest.TestCase):
         self.assertIn("errors", data)
         self.assertTrue(len(data["errors"]) > 0)
 
-    def test_list(self):
+    def test_list_jobs(self):
         """
         Test list_jobs and list_endpoint methods
         """
-        tx_manager = TxManager(api_url=self.MOCK_API_URL, gogs_url=self.MOCK_GOGS_URL)
+        tx_manager = TxManager(**self.tx_manager_env_vars)
         jobs = tx_manager.list_jobs({"gogs_user_token": "token2"}, True)
         expected = [TxJob(job).get_db_data()
                     for job in ManagerTest.mock_job_db.mock_data.values()]
@@ -422,7 +436,7 @@ class ManagerTest(unittest.TestCase):
                           ["GET", "POST", "PUT", "PATCH", "DELETE"])
 
     def test_register_module(self):
-        manager = TxManager(api_url=self.MOCK_API_URL)
+        manager = TxManager(**self.tx_manager_env_vars)
 
         data = {
             "name": "module1",
@@ -459,7 +473,7 @@ class ManagerTest(unittest.TestCase):
         """
         Test [get/update/delete]_job methods
         """
-        manager = TxManager()
+        manager = TxManager(**self.tx_manager_env_vars)
 
         # get_job
         job = manager.get_job(0)
@@ -484,7 +498,7 @@ class ManagerTest(unittest.TestCase):
         """
         Test [get/update/delete]_module methods
         """
-        manager = TxManager()
+        manager = TxManager(**self.tx_manager_env_vars)
 
         # get_module
         module = manager.get_module("module1")


### PR DESCRIPTION
Makes it possible to set what tables in DynamoDB TxManager uses for jobs and modules through State environment variables passed to the lambda function. This adds those variables to the env_vars passed to TxManager in each lambda function that makes an instant of TxManager (including start_job which is triggered by a DynamoDB INSERT), and standardizes the variables for test_manager.py.