### PR TITLE
Feature - Update for Issue #503 - Uses json to print input_format and output_format

### DIFF
--- a/manager/manager.py
+++ b/manager/manager.py
@@ -503,11 +503,11 @@ class TxManager(object):
                     'html.parser'))
                 body.table.append(BeautifulSoup(
                     '<tr id="' + item['name'] + '-input" class="module-input"><td class="lbl">Input Format:</td><td>' +
-                    str(item["input_format"]) + '</td></tr>',
+                    json.dumps(item["input_format"]) + '</td></tr>',
                     'html.parser'))
                 body.table.append(BeautifulSoup(
                     '<tr id="' + item['name'] + '-output" class="module-output"><td class="lbl">Output Format:</td><td>' +
-                    str(item["output_format"]) + '</td></tr>',
+                    json.dumps(item["output_format"]) + '</td></tr>',
                     'html.parser'))
                 body.table.append(BeautifulSoup(
                     '<tr id="' + item['name'] + '-resource" class="module-resource"><td class="lbl">Resource Types:</td><td>' +


### PR DESCRIPTION
input_format and output_format are actually lists, so needed to use json.dumps() to print them like other list values. Can be seen at https://test-api.door43.org/dashboard