### PR TITLE
Feature - Isse #503 - Stage environment variables needed for dashboard to read proper tables

### DIFF
--- a/lambda_handlers/dashboard_handler.py
+++ b/lambda_handlers/dashboard_handler.py
@@ -17,5 +17,11 @@ class DashboardHandler(Handler):
         if 'body-json' in event and isinstance(event['body-json'], dict):
             data.update(event['body-json'])
         # Set required env_vars
-        env_vars = {}
+        env_vars = {
+            'api_url': self.retrieve(event['vars'], 'api_url', 'Environment Vars'),
+            'gogs_url': self.retrieve(event['vars'], 'gogs_url', 'Environment Vars'),
+            'cdn_url': self.retrieve(event['vars'], 'cdn_url', 'Environment Vars'),
+            'job_table_name': self.retrieve(event['vars'], 'job_table_name', 'Environment Vars'),
+            'module_table_name': self.retrieve(event['vars'], 'module_table_name', 'Environment Vars')
+        }
         return TxManager(**env_vars).generate_dashboard()

--- a/tests/lambda_handlers_tests/test_dashboardHandler.py
+++ b/tests/lambda_handlers_tests/test_dashboardHandler.py
@@ -17,8 +17,11 @@ class TestListJobsHandler(TestCase):
                 'gogs_url': 'https://git.example.com',
                 'cdn_url': 'https://cdn.exmaple.com',
                 'api_url': 'https://api.example.com',
-                'cdn_bucket': 'cdn_test_bucket'
+                'cdn_bucket': 'cdn_test_bucket',
+                'job_table_name': 'test-tx-job',
+                'module_table_name': 'test-tx-module'
             }
         }
         handler = DashboardHandler()
         self.assertIsNone(handler.handle(event, None))
+


### PR DESCRIPTION
For Issue #503, since we have dev and prod DBs together, dashboard needs to know which table to read from. Includes getting all variables we set in the stage environment variables.