### PR TITLE
Fixes parsing response from converter in start_job

### DIFF
--- a/converters/converter.py
+++ b/converters/converter.py
@@ -64,7 +64,7 @@ class Converter(object):
             self.logger.error('Resource "{0}" not currently supported'.format(self.resource))
 
         return {
-            'status': len(self.logger.logs['error']) == 0,
+            'success': len(self.logger.logs['error']) == 0,
             'info': self.logger.logs['info'],
             'warnings': self.logger.logs['warning'],
             'errors': self.logger.logs['error']

--- a/converters/md2html_converter.py
+++ b/converters/md2html_converter.py
@@ -52,8 +52,6 @@ class Md2HtmlConverter(Converter):
                     self.logger.warning(warning)
                 for error in inspector.logger.logs["error"]:
                     self.logger.error(error)
-
-
             else:
                 # Directly copy over files that are not markdown files
                 try:

--- a/door43_tools/project_deployer.py
+++ b/door43_tools/project_deployer.py
@@ -107,8 +107,7 @@ class ProjectDeployer(object):
             html = """
                 <html lang="en">
                     <head>
-                        <title>{0}</title>'
-
+                        <title>{0}</title>
                     </head>
                     <body>
                         <div id="content">{1}</div>

--- a/door43_tools/templaters.py
+++ b/door43_tools/templaters.py
@@ -57,7 +57,7 @@ class Templater(object):
     def build_page_nav(self, filename=None):
         html = """
             <nav class="affix-top hidden-print hidden-xs hidden-sm" id="right-sidebar-nav">
-              <ul id="sidebar-nav" class="nav nav-stacked affix">
+              <ul id="sidebar-nav" class="nav nav-stacked">
                 <li><h1>Navigation</h1></li>
             """
         for fname in self.files:

--- a/door43_tools/templaters.py
+++ b/door43_tools/templaters.py
@@ -67,6 +67,8 @@ class Templater(object):
                 title = soup.h1.text
             else:
                 title = os.path.splitext(os.path.basename(fname))[0].replace('_', ' ').capitalize()
+            if title == "Conversion requested...":
+                continue
             if filename != fname:
                 html += '<li><a href="{0}">{1}</a></li>'.format(os.path.basename(fname),title)
             else:
@@ -200,6 +202,8 @@ class BibleTemplater(Templater):
                 title = soup.find('h1').text
             else:
                 title = '{0}.'.format(book_code)
+            if title == "Conversion requested...":
+                continue
             html += """
                 <div class="panel panel-default">
                     <div class="panel-heading">

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -249,22 +249,23 @@ class TxManager(object):
                     if error.startswith('Bad Request: '):
                         error = error[len('Bad Request: '):]
                     job.error_message(error)
-            for message in json_data['info']:
-                if message:
-                    job.log_message(message)
-            for message in json_data['errors']:
-                if message:
-                    job.error_message(message)
-            for message in json_data['warnings']:
-                if message:
-                    job.warning_message(message)
-            success = json_data['success']
-            if json_data['errors']:
-                job.log_message('{0} function returned with errors.'.format(module.name))
-            elif json_data['warnings']:
-                job.log_message('{0} function returned with warnings.'.format(module.name))
-            elif json_data['log']:
-                job.log_message('{0} function returned.'.format(module.name))
+                elif 'success' in json_data:
+                    success = json_data['success']
+                    for message in json_data['info']:
+                        if message:
+                            job.log_message(message)
+                    for message in json_data['errors']:
+                        if message:
+                            job.error_message(message)
+                    for message in json_data['warnings']:
+                        if message:
+                            job.warning_message(message)
+                    if json_data['errors']:
+                        job.log_message('{0} function returned with errors.'.format(module.name))
+                    elif json_data['warnings']:
+                        job.log_message('{0} function returned with warnings.'.format(module.name))
+                    else:
+                        job.log_message('{0} function returned successfully.'.format(module.name))
         except Exception as e:
             job.error_message('Failed with message: {0}'.format(e.message))
 

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -244,6 +244,14 @@ class TxManager(object):
             json_data = response.json()
             if json_data:
                 json_data = response.json()
+                # The json_data of the response could result in a few different formats:
+                # 1) It could be that an exception was thrown in the converter code, which the API Gateway puts
+                #    into a json array with "errorMessage" containing the exception message.
+                # 2) If a "success" key is in the payload, that means our code finished with
+                #    the expected results (see converters/converter.py's run() return value).
+                # 3) The other possibility is for the Lambda function to not finish executing
+                #    (e.g. exceeds its 5 minute execution limit). We don't currently handle this possibility.
+                # Todo: Handle lambda function returning due to exceeding 5 minutes execution limit
                 if 'errorMessage' in json_data:
                     error = json_data['errorMessage']
                     if error.startswith('Bad Request: '):

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -249,31 +249,22 @@ class TxManager(object):
                     if error.startswith('Bad Request: '):
                         error = error[len('Bad Request: '):]
                     job.error_message(error)
-
-            if 'Payload' in json_data:
-                payload = json_data['Payload']
-
-                print('Payload:')
-                print(json.dumps(payload))
-
-                for message in payload['log']:
-                    if message:
-                        job.log_message(message)
-                for message in payload['errors']:
-                    if message:
-                        job.error_message(message)
-                for message in payload['warnings']:
-                    if message:
-                        job.warning_message(message)
-
-                success = payload['success']
-
-                if payload['errors']:
-                    job.log_message('{0} function returned with errors.'.format(module.name))
-                elif payload['warnings']:
-                    job.log_message('{0} function returned with warnings.'.format(module.name))
-                elif payload['log']:
-                    job.log_message('{0} function returned.'.format(module.name))
+            for message in json_data['info']:
+                if message:
+                    job.log_message(message)
+            for message in json_data['errors']:
+                if message:
+                    job.error_message(message)
+            for message in json_data['warnings']:
+                if message:
+                    job.warning_message(message)
+            success = json_data['success']
+            if json_data['errors']:
+                job.log_message('{0} function returned with errors.'.format(module.name))
+            elif json_data['warnings']:
+                job.log_message('{0} function returned with warnings.'.format(module.name))
+            elif json_data['log']:
+                job.log_message('{0} function returned.'.format(module.name))
         except Exception as e:
             job.error_message('Failed with message: {0}'.format(e.message))
 

--- a/tests/converter_tests/test_md2html_converter.py
+++ b/tests/converter_tests/test_md2html_converter.py
@@ -184,7 +184,7 @@ class TestMd2HtmlConverter(unittest.TestCase):
             contents = self.getContents(file_path)
             self.assertIsNone(contents, 'OBS HTML body contents present, but should not be: {0}'.format(os.path.basename(file_path)))
 
-        self.assertEqual(self.return_val['status'], self.expected_success, "Mismatch in status")
+        self.assertEqual(self.return_val['success'], self.expected_success, "Mismatch in for success boolean")
         self.assertEqual(len(self.return_val['info']) == 0, self.expected_info_empty, "Mismatch in expected info empty")
         for warning in self.return_val['warnings']:
             print("Warning: " + warning)

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -41,51 +41,51 @@ class ManagerTest(unittest.TestCase):
     def setUpClass(cls):
         """Create mock AWS handlers, and apply corresponding monkey patches."""
         cls.mock_job_db = mock_utils.mock_db_handler(data={
-            0: {
-                "job_id": 0,
+            "0": {
+                "job_id": "0",
                 "status": "started",
                 "resource_type": "obs",
                 "input_format": "md",
                 "output_format": "html"
             },
-            1: {
-                "job_id": 1,
+            "1": {
+                "job_id": "1",
                 "status": "requested",
                 "resource_type": "obs",
                 "input_format": "md",
                 "output_format": "html"
             },
-            2: {
-                "job_id": 2,
+            "2": {
+                "job_id": "2",
                 "status": "requested",
                 "resource_type": "ulb",
                 "input_format": "usfm",
                 "output_format": "html",
                 "callback": ManagerTest.MOCK_CALLBACK_URL,
             },
-            3: {
-                "job_id": 3,
+            "3": {
+                "job_id": "3",
                 "status": "requested",
                 "resource_type": "other",
                 "input_format": "md",
                 "output_format": "html"
             },
-            4: {
-                "job_id": 4,
+            "4": {
+                "job_id": "4",
                 "status": "requested",
                 "resource_type": "unsupported",
                 "input_format": "md",
                 "output_format": "html"
             },
-            6: {
-                "job_id": 6,
+            "6": {
+                "job_id": "6",
                 "status": "requested",
                 "resource_type": "obs",
                 "input_format": "md",
                 "output_format": "html"
             },
-            7: {
-                "job_id": 7,
+            "7": {
+                "job_id": "7",
                 "status": "requested",
                 "resource_type": "obs",
                 "input_format": "md",
@@ -301,14 +301,14 @@ class ManagerTest(unittest.TestCase):
         }, 200)
 
         tx_manager = TxManager(**self.tx_manager_env_vars)
-        tx_manager.start_job(1)
+        tx_manager.start_job("1")
 
         # job1's entry in database should have been updated
         args, kwargs = self.call_args(ManagerTest.mock_job_db.update_item, num_args=2)
         keys = args[0]
         self.assertIsInstance(keys, dict)
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 1)
+        self.assertEqual(keys["job_id"], "1")
         data = args[1]
         self.assertIsInstance(data, dict)
         self.assertIn("errors", data)
@@ -332,7 +332,7 @@ class ManagerTest(unittest.TestCase):
             "message": "All good"
         }, 200)
         tx_manager = TxManager(**self.tx_manager_env_vars)
-        tx_manager.start_job(2)
+        tx_manager.start_job("2")
 
         # job2's entry in database should have been updated
         ManagerTest.mock_job_db.update_item.assert_called()
@@ -340,7 +340,7 @@ class ManagerTest(unittest.TestCase):
         keys = args[0]
         self.assertIsInstance(keys, dict)
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 2)
+        self.assertEqual(keys["job_id"], "2")
         data = args[1]
         self.assertIsInstance(data, dict)
         self.assertIn("errors", data)
@@ -366,14 +366,14 @@ class ManagerTest(unittest.TestCase):
         }, 200)
 
         manager = TxManager(**self.tx_manager_env_vars)
-        manager.start_job(3)
+        manager.start_job("3")
 
         # job3's entry in database should have been updated
         ManagerTest.mock_job_db.update_item.assert_called()
         args, kwargs = self.call_args(ManagerTest.mock_job_db.update_item, num_args=2)
         keys = args[0]
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 3)
+        self.assertEqual(keys["job_id"], "3")
         self.assertIsInstance(keys, dict)
         data = args[1]
         self.assertIsInstance(data, dict)
@@ -383,13 +383,13 @@ class ManagerTest(unittest.TestCase):
     def test_start_job_failure(self):
         """Call start_job with non-runnable/non-existent jobs."""
         tx_manager = TxManager(**self.tx_manager_env_vars)
-        ret0 = tx_manager.start_job(0)
-        ret4 = tx_manager.start_job(4)
-        ret5 = tx_manager.start_job(5)
+        ret0 = tx_manager.start_job("0")
+        ret4 = tx_manager.start_job("4")
+        ret5 = tx_manager.start_job("5")
 
-        self.assertEqual(ret0['job_id'], 0)
-        self.assertEqual(ret4['job_id'], 4)
-        self.assertEqual(ret5['job_id'], 5)
+        self.assertEqual(ret0['job_id'], "0")
+        self.assertEqual(ret4['job_id'], "4")
+        self.assertEqual(ret5['job_id'], "5")
         self.assertFalse(ret5['success'])
         self.assertEqual(ret5['message'], 'No job with ID 5 has been requested')
 
@@ -399,11 +399,11 @@ class ManagerTest(unittest.TestCase):
         keys = args[0]
         self.assertIsInstance(keys, dict)
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 4)
+        self.assertEqual(keys["job_id"], "4")
         data = args[1]
         self.assertIsInstance(data, dict)
         self.assertIn("job_id", data)
-        self.assertEqual(data["job_id"], 4)
+        self.assertEqual(data["job_id"], "4")
         self.assertIn("errors", data)
         self.assertTrue(len(data["errors"]) > 0)
 
@@ -418,14 +418,14 @@ class ManagerTest(unittest.TestCase):
         error_to_check = "something bad happened!"
         mock_requests_post.return_value = MockResponse({"errorMessage": 'Bad Request: {0}'.format(error_to_check)}, 400)
         tx_manager = TxManager(**self.tx_manager_env_vars)
-        tx_manager.start_job(6)
+        tx_manager.start_job("6")
         # job 0's entry in database should have been updated
         ManagerTest.mock_job_db.update_item.assert_called()
         args, kwargs = self.call_args(ManagerTest.mock_job_db.update_item, num_args=2)
         keys = args[0]
         self.assertIsInstance(keys, dict)
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 6)
+        self.assertEqual(keys["job_id"], "6")
         data = args[1]
         self.assertIsInstance(data, dict)
         self.assertIn("errors", data)
@@ -452,14 +452,14 @@ class ManagerTest(unittest.TestCase):
         }, 200)
 
         manager = TxManager(**self.tx_manager_env_vars)
-        manager.start_job(7)
+        manager.start_job("7")
 
         # job 7's entry in database should have been updated
         ManagerTest.mock_job_db.update_item.assert_called()
         args, kwargs = self.call_args(ManagerTest.mock_job_db.update_item, num_args=2)
         keys = args[0]
         self.assertIn("job_id", keys)
-        self.assertEqual(keys["job_id"], 7)
+        self.assertEqual(keys["job_id"], "7")
         self.assertIsInstance(keys, dict)
         data = args[1]
         self.assertIsInstance(data, dict)
@@ -532,23 +532,23 @@ class ManagerTest(unittest.TestCase):
         manager = TxManager(**self.tx_manager_env_vars)
 
         # get_job
-        job = manager.get_job(0)
+        job = manager.get_job("0")
         self.assertIsInstance(job, TxJob)
-        self.assertEqual(job.job_id, 0)
+        self.assertEqual(job.job_id, "0")
         self.assertEqual(job.status, "started")
 
         # update_job
         manager.update_job(job)
         args, kwargs = self.call_args(ManagerTest.mock_job_db.update_item,
                                       num_args=2)
-        self.assertEqual(args[0], {"job_id": 0})
+        self.assertEqual(args[0], {"job_id": "0"})
         self.assertEqual(args[1], job.get_db_data())
 
         # delete_job
         manager.delete_job(job)
         args, kwargs = self.call_args(ManagerTest.mock_job_db.delete_item,
                                       num_args=1)
-        self.assertEqual(args[0], {"job_id": 0})
+        self.assertEqual(args[0], {"job_id": "0"})
 
     def test_get_update_delete_module(self):
         """Test [get/update/delete]_module methods."""


### PR DESCRIPTION
There was a a bug in reading the response from the converter API call in start_job. We don't need to read 'Payload' any more.