### PR TITLE
Fixes immediate download problem with S3

### DIFF
--- a/converters/converter.py
+++ b/converters/converter.py
@@ -58,7 +58,7 @@ class Converter(object):
                 add_contents_to_zip(self.output_zip_file, self.output_dir)
                 # upload the output archive either to cdn_bucket or to a file (no cdn_bucket)
                 self.upload_archive()
-            except Exception as e:
+            except:
                 self.logger.error('Conversion process ended abnormally')
         else:
             self.logger.error('Resource "{0}" not currently supported'.format(self.resource))

--- a/converters/usfm2html_converter.py
+++ b/converters/usfm2html_converter.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, unicode_literals
 import os
 import tempfile
-import string
 import codecs
 from bs4 import BeautifulSoup
 from shutil import copyfile

--- a/door43_tools/templaters.py
+++ b/door43_tools/templaters.py
@@ -183,7 +183,7 @@ class BibleTemplater(Templater):
     def build_page_nav(self, filename=None):
         html = """
         <nav class="affix-top hidden-print hidden-xs hidden-sm" id="right-sidebar-nav">
-            <ul id="sidebar-nav" class="nav nav-stacked books panel-group">
+            <ul id="sidebar-nav" class="affix affix-top nav nav-stacked books panel-group">
             """
         for fname in self.files:
             filebase = os.path.splitext(os.path.basename(fname))[0]


### PR DESCRIPTION
Seems that a 3.6 MB file (First five books of the Bible in HTML zipped) takes a while to be downloadable from S3 after we upload it in the converter module. Even though it gets uploaded, can't view it almost a minute later, so I added a sleep cycle in the client_callback to keep trying to download the zip file for 5 minutes.