### PR TITLE
Fix 538 Job Count on dashboard is too low

### DIFF
--- a/aws_tools/dynamodb_handler.py
+++ b/aws_tools/dynamodb_handler.py
@@ -73,7 +73,7 @@ class DynamoDBHandler(object):
             Key=keys
         )
 
-    def query_items(self, query=None, only_fields_with_values=True):
+    def query_items(self, query=None, only_fields_with_values=True, exclusive_start_key=None):
         filter_expression = None
         if query and len(query) > 1:
             for field, value in iteritems(query):
@@ -118,13 +118,26 @@ class DynamoDBHandler(object):
                     filter_expression &= condition
 
         if filter_expression is not None:
-            response = self.table.scan(
-                FilterExpression=filter_expression
-            )
+            if exclusive_start_key == None:
+                response = self.table.scan(
+                    FilterExpression=filter_expression
+                )
+            else:
+                response = self.table.scan(
+                    FilterExpression=filter_expression,
+                    ExclusiveStartKey = exclusive_start_key
+                )
         else:
-            response = self.table.scan()
+            if exclusive_start_key == None:
+                response = self.table.scan()
+            else:
+                response = self.table.scan(ExclusiveStartKey = exclusive_start_key)
 
+        self.partial_data = False
         if response and 'Items' in response:
+            if 'LastEvaluatedKey' in response:
+                self.partial_data = True
+                self.last_key = response['LastEvaluatedKey']
             return response['Items']
         else:
             return None

--- a/aws_tools/dynamodb_handler.py
+++ b/aws_tools/dynamodb_handler.py
@@ -133,14 +133,13 @@ class DynamoDBHandler(object):
             else:
                 response = self.table.scan(ExclusiveStartKey = exclusive_start_key)
 
-        self.partial_data = False
+        last_key = None
         if response and 'Items' in response:
             if 'LastEvaluatedKey' in response:
-                self.partial_data = True
-                self.last_key = response['LastEvaluatedKey']
-            return response['Items']
+                last_key = response['LastEvaluatedKey']
+            return response['Items'], last_key
         else:
-            return None
+            return None, last_key
 
 
 RESERVED_WORDS = [

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -415,15 +415,14 @@ class TxManager(object):
         self.job_db_handler.insert_item(job_data)
 
     def query_jobs(self, data=None):
-        items = self.job_db_handler.query_items(data)
+        items, last_key = self.job_db_handler.query_items(data)
         jobs = []
         if items and len(items):
             for item in items:
                 jobs.append(TxJob(item))
 
-        while self.job_db_handler.partial_data:
-            exclusive_start_key = self.job_db_handler.last_key
-            items = self.job_db_handler.query_items(data, exclusive_start_key = exclusive_start_key)
+        while last_key != None:
+            items, last_key = self.job_db_handler.query_items(data, exclusive_start_key=last_key)
             if items and len(items):
                 for item in items:
                     jobs.append(TxJob(item))
@@ -444,7 +443,7 @@ class TxManager(object):
         self.module_db_handler.insert_item(module_data)
 
     def query_modules(self, data=None):
-        items = self.module_db_handler.query_items(data)
+        items, last_key = self.module_db_handler.query_items(data)
         modules = []
         if items and len(items):
             for item in items:
@@ -476,7 +475,8 @@ class TxManager(object):
             'body': 'No modules found'
         }
 
-        items = sorted(self.module_db_handler.query_items(), key=lambda k: k['name'])
+        query_items, last_key = self.module_db_handler.query_items()
+        items = sorted(query_items, key=lambda k: k['name'])
         totalJobs = self.list_jobs({},False)
         self.getMissingConvertModules(items, totalJobs)
 

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -630,20 +630,17 @@ class TxManager(object):
         self.jobs_failures = 0
         self.jobs_success = 0
         for job in jobs:
-            try:
-                errors = job['errors']
-                if len(errors) > 0:
-                    self.jobs_failures+=1
-                    continue
-
-                warnings = job['warnings']
-                if len(warnings) > 0:
-                    self.jobs_warnings+=1
-                    continue
-
-                self.jobs_success+=1
-
-            except:
+            errors = job['errors']
+            if len(errors) > 0:
                 self.jobs_failures+=1
+                continue
+
+            warnings = job['warnings']
+            if len(warnings) > 0:
+                self.jobs_warnings+=1
+                continue
+
+            self.jobs_success+=1
+
 
 

--- a/manager/manager.py
+++ b/manager/manager.py
@@ -602,7 +602,7 @@ class TxManager(object):
             if module != None: # if unregistered module, add dummy entry
                 entry = {
                     "input_format" : "",
-                    "name" : "unregistered: " + module,
+                    "name" : module,
                     "options" : [],
                     "output_format" : [],
                     "private_links" : [],
@@ -610,6 +610,7 @@ class TxManager(object):
                     "resource_types" : [],
                     "type" : "",
                     "version" : "",
+                    "unregistered" : True
                 }
                 convertModules.append(entry)
 

--- a/tests/aws_tools_tests/test_dynamodbHandler.py
+++ b/tests/aws_tools_tests/test_dynamodbHandler.py
@@ -85,12 +85,14 @@ class DynamoDBHandlerTests(unittest.TestCase):
             }
             data = {"age": 30, "full_name": "John Doe"}
             self.handler.table.scan.return_value = {"Items": data}
-            self.assertEqual(self.handler.query_items(query), data)
+            items, last_key = self.handler.query_items(query)
+            self.assertEqual(items, data)
             self.handler.table.scan.assert_called_once()
 
     def test_query_item_no_query(self):
         """Test a invocation of `query_item` with no query."""
         data = {"age": 30, "full_name": "John Doe"}
         self.handler.table.scan.return_value = {"Items": data}
-        self.assertEqual(self.handler.query_items(), data)
+        items, last_key = self.handler.query_items()
+        self.assertEqual(items, data)
         self.handler.table.scan.assert_called_once_with()

--- a/tests/manager_tests/mock_utils.py
+++ b/tests/manager_tests/mock_utils.py
@@ -19,8 +19,8 @@ def mock_db_handler(data, keyname):
             return data[key]
         return None
 
-    def query_items(*ignored):
-        return data.values()
+    def query_items(query=None, only_fields_with_values=True, exclusive_start_key=None):
+        return data.values(), None
 
     handler = MagicMock()
     handler.get_item = MagicMock(side_effect=get_item)

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -102,6 +102,14 @@ class ManagerTest(unittest.TestCase):
                 "input_format": "md",
                 "output_format": "html",
                 "convert_module": "module2"
+            },
+            "8": {
+                "job_id": "8",
+                "status": "requested",
+                "resource_type": "obs",
+                "input_format": "html",
+                "output_format": "pdf",
+                "convert_module": "module4"
             }
         }, keyname="job_id")
         cls.mock_module_db = mock_utils.mock_db_handler(data={
@@ -613,6 +621,14 @@ class ManagerTest(unittest.TestCase):
         moduleName = 'module3'
         expectedRowCount = 9
         expectedSuccessCount = 0
+        expectedWarningCount = 0
+        expectedFailureCount = 0
+        self.validateModule(soup, moduleName, expectedRowCount, expectedSuccessCount, expectedFailureCount,
+                            expectedWarningCount)
+
+        moduleName = 'module4'
+        expectedRowCount = 9
+        expectedSuccessCount = 1
         expectedWarningCount = 0
         expectedFailureCount = 0
         self.validateModule(soup, moduleName, expectedRowCount, expectedSuccessCount, expectedFailureCount,

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -636,7 +636,7 @@ class ManagerTest(unittest.TestCase):
 
         moduleName = 'totals'
         expectedRowCount = 4
-        expectedSuccessCount = 4
+        expectedSuccessCount = 5
         expectedWarningCount = 2
         expectedFailureCount = 1
         self.validateModule(soup, moduleName, expectedRowCount, expectedSuccessCount, expectedFailureCount,


### PR DESCRIPTION
Fix https://github.com/unfoldingWord-dev/door43.org/issues/538 Job Count on dashboard is too low

Issue was that DynamoDBHandler.query_items() needed to check for when only a partial download occurred and to continue to download in chunks.

Fixes:
- DynamoDBHandler.query_items() - fix for when return data exceeds 1MB  added exclusive_start_key parameter and detection when query returns partial data.
- TxManager.query_jobs() - added fix to for when only partial data is returned.  Continues to query until all data fetched.
- TxManager.generate_dashboard() - added check for unregistered modules in jobs.