### PR TITLE
Fixes #482 - Change converters so that the converter class determines how to convert

### DIFF
--- a/converters/md2html_converter.py
+++ b/converters/md2html_converter.py
@@ -3,7 +3,6 @@ import os
 import string
 import markdown
 import codecs
-from glob import glob
 from shutil import copyfile
 from general_tools.file_utils import write_file
 from converter import Converter
@@ -13,8 +12,16 @@ from door43_tools.obs_data import obs_data
 
 class Md2HtmlConverter(Converter):
 
+    def convert(self):
+        if self.resource == "obs":
+            self.convert_obs()
+            return True
+        else:
+            self.convert_markdown()
+            return True
+
     def convert_obs(self):
-        self.logger.info('Processing the OBS markdown files')
+        self.log.info('Processing OBS markdown files')
 
         # find the first directory that has md files.
         files = self.get_files()
@@ -37,15 +44,15 @@ class Md2HtmlConverter(Converter):
                 html_filename = base_name + ".html"
                 output_file = os.path.join(self.output_dir, html_filename)
                 write_file(output_file, html)
-                self.logger.info('Converted {0} to {1}.'.format(os.path.basename(filename), os.path.basename(html_filename)))
+                self.log.info('Converted {0} to {1}.'.format(os.path.basename(filename), os.path.basename(html_filename)))
 
                 # Do the OBS inspection (this now operates on a single file instead of folder)
                 # QUESTION: Should this be done separately after conversion????
-                inspector = OBSInspection(output_file, self.logger)
+                inspector = OBSInspection(output_file, self.log)
                 try:
                     inspector.run()
                 except Exception as e:
-                    self.logger.warning('Chapter {0}: failed to run OBS inspector: {1}'.format(base_name, e.message))
+                    self.log.warning('Chapter {0}: failed to run OBS inspector: {1}'.format(base_name, e.message))
             else:
                 # Directly copy over files that are not markdown files
                 try:
@@ -58,6 +65,41 @@ class Md2HtmlConverter(Converter):
         for chapter in sorted(obs_data['chapters']): # verify all expected chapters are present
             found_chapter = found_chapters.get(chapter)
             if not found_chapter:
-                self.logger.warning('Chapter {0} is missing!'.format(chapter))
+                self.log.warning('Chapter {0} is missing!'.format(chapter))
 
-        self.logger.info('Finished processing Markdown files.')
+        self.log.info('Finished processing OBS Markdown files.')
+
+    def convert_markdown(self):
+        self.log.info('Processing Markdown files')
+
+        # find the first directory that has md files.
+        files = self.get_files()
+
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(current_dir, 'templates', 'template.html')) as template_file:
+            html_template = string.Template(template_file.read())
+
+        found_chapters = {}
+
+        for filename in files:
+            if filename.endswith('.md'):
+                # Convert files that are markdown files
+                with codecs.open(filename, 'r', 'utf-8-sig') as md_file:
+                    md = md_file.read()
+                html = markdown.markdown(md)
+                html = html_template.safe_substitute(title=self.resource.upper(), content=html)
+                base_name = os.path.splitext(os.path.basename(filename))[0]
+                found_chapters[base_name] = True
+                html_filename = base_name + ".html"
+                output_file = os.path.join(self.output_dir, html_filename)
+                write_file(output_file, html)
+                self.log.info('Converted {0} to {1}.'.format(os.path.basename(filename), os.path.basename(html_filename)))
+            else:
+                # Directly copy over files that are not markdown files
+                try:
+                    output_file = os.path.join(self.output_dir, os.path.basename(filename))
+                    if not os.path.exists(output_file):
+                        copyfile(filename, output_file)
+                except:
+                    pass
+        self.log.info('Finished processing Markdown files.')

--- a/converters/templates/template.html
+++ b/converters/templates/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>$title</title>
+</head>
+<body>
+<div id="content" class="content">
+$content
+</div>
+</body>
+</html>

--- a/converters/usfm2html_converter.py
+++ b/converters/usfm2html_converter.py
@@ -11,14 +11,16 @@ from usfm_tools.transform import UsfmTransform
 
 class Usfm2HtmlConverter(Converter):
 
-    def convert_udb(self):
-        self.convert_bible()
-
-    def convert_ulb(self):
-        self.convert_bible()
+    def convert(self):
+        if self.resource in ['ulb', 'udb', 'bible']:
+            self.convert_bible()
+            return True
+        else:
+            return False
 
     def convert_bible(self):
-        self.logger.info('Processing the Bible USFM files')
+        self.log.info('Processing the Bible USFM files')
+        self.logger.debug('Processing the Bible USFM files')
 
         # find the first directory that has usfm files.
         files = self.get_files()
@@ -45,8 +47,10 @@ class Usfm2HtmlConverter(Converter):
                 content_div.body.unwrap()
                 output_file = os.path.join(self.output_dir, html_filename)
                 write_file(output_file, template_soup.prettify())
-                self.logger.info('Converted {0} to {1}.'.format(os.path.basename(filename),
-                                                                os.path.basename(html_filename)))
+                self.log.info('Converted {0} to {1}.'.format(os.path.basename(filename),
+                                                              os.path.basename(html_filename)))
+                self.logger.debug('Converted {0} to {1}.'.format(os.path.basename(filename),
+                                                              os.path.basename(html_filename)))
                 remove_tree(scratch_dir)
 
                 # TODO 3/30/17 BLM - should be an inspection here like OBS has?
@@ -60,16 +64,13 @@ class Usfm2HtmlConverter(Converter):
                 except:
                     pass
 
-        manifest_file = os.path.join(self.files_dir, 'manifest.json')
-        if os.path.isfile(manifest_file):
-            copyfile(manifest_file, os.path.join(self.output_dir, 'manifest.json'))
-
         # Do the Bible inspection HERE
-        #        inspector = BibleInspection(self.output_dir, self.logger)
+        #        inspector = BibleInspection(self.output_dir, self.log)
         #        inspector.run()
         #        complete_html = html_template.safe_substitute(content=complete_html)
         #        write_file(os.path.join(self.output_dir, 'all.html'), complete_html)
         #        self.log_message('Made one HTML of all bibles in all.html.')
         #        self.log_message('Finished processing Markdown files.')
 
-        self.logger.info('Finished processing Bible USFM files.')
+        self.log.info('Finished processing Bible USFM files.')
+        self.logger.debug('Finished processing Bible USFM files.')

--- a/tests/converter_tests/test_usfm2html_converter.py
+++ b/tests/converter_tests/test_usfm2html_converter.py
@@ -98,6 +98,22 @@ class TestUsfmHtmlConverter(unittest.TestCase):
             self.assertIsNotNone(usfm);
             self.assertTrue(len(usfm) > 10, 'Bible usfm file contents missing: {0}'.format(file_to_verify))
 
+    def test_bad_source(self):
+        """This tests giving a bad resource type to the converter"""
+        with closing(Usfm2HtmlConverter('bad_source', 'bad_resource')) as tx:
+            result = tx.run()
+        self.assertFalse(result['success'])
+        self.assertEqual(result['errors'], [u'Conversion process ended abnormally: Failed to download bad_source'])
+
+    def test_bad_resource(self):
+        """This tests giving a bad resource type to the converter"""
+        zip_file = self.resources_dir + "/51-PHP.zip"
+        with closing(Usfm2HtmlConverter('', 'bad_resource')) as tx:
+            tx.input_zip_file = zip_file
+            result = tx.run()
+        self.assertFalse(result['success'])
+        self.assertEqual(result['errors'], ['Resource bad_resource currently not supported.'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Note, there is a self.logger which is for tx-manager logging to the Lambda log files (viewed with `apex logs`) and there is the self.log which is the converter log which gets displayed on the live.door43.org page to the user.