### PR TITLE
Feature - Issue 547 - Fix links in tA output

### DIFF
--- a/tests/client_tests/test_ta_preprocessor.py
+++ b/tests/client_tests/test_ta_preprocessor.py
@@ -5,7 +5,7 @@ import unittest
 import shutil
 import markdown
 from resource_container.ResourceContainer import RC
-from client.preprocessors import do_preprocess
+from client.preprocessors import do_preprocess, TaPreprocessor
 from general_tools.file_utils import unzip, read_file
 from bs4 import BeautifulSoup
 
@@ -37,10 +37,87 @@ class TestTaPreprocessor(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'intro.md')))
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'process.md')))
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'translate.md')))
-        soup = BeautifulSoup(markdown.markdown(read_file(os.path.join(self.out_dir, 'checking.md'))), 'html.parser')
+        checking = read_file(os.path.join(self.out_dir, 'checking.md'))
+        intro = read_file(os.path.join(self.out_dir, 'intro.md'))
+        process = read_file(os.path.join(self.out_dir, 'process.md'))
+        translate = read_file(os.path.join(self.out_dir, 'translate.md'))
+        soup = BeautifulSoup(markdown.markdown(checking), 'html.parser')
         self.assertEqual(soup.h1.text, "Checking Manual")
         self.assertIsNotNone(soup.find("a", {"name": "accurate"}))
         self.assertEqual(len(soup.find_all('li')), 350)
+        # Test links have been converted
+        self.assertIsNotNone(soup.find("a", {"href": "#accuracy-check"}))
+        self.assertIsNotNone(soup.find("a", {"href": "translate.html#figs-explicit"}))
+        # make sure no old links exist
+        self.assertTrue('../' not in checking)
+        self.assertTrue('../' not in intro)
+        self.assertTrue('../' not in process)
+        self.assertTrue('../' not in translate)
+
+    def test_fix_links(self):
+        content = "This has [links](../section1/01.md) to the same [manual](../section2/01.md)"
+        expected = "This has [links](#section1) to the same [manual](#section2)"
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
+ 
+        content = """This has links to 
+        [other](../../other_manual1/section1/01.md) [manuals](../../other_manual2/section2/01.md)"""
+        expected = """This has links to 
+        [other](other_manual1.html#section1) [manuals](other_manual2.html#section2)"""
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
+
+        content = """This has links to both this [manual](../section1/01.md),
+         this [page](section2) and [another manual](../../another_manual/section3/01.md)."""
+        expected = """This has links to both this [manual](#section1),
+         this [page](#section2) and [another manual](another_manual.html#section3)."""
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
+
+        content = """This link should NOT be converted: [webpage](http://example.com/somewhere/outthere) """
+        expected = """This link should NOT be converted: [webpage](http://example.com/somewhere/outthere) """
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
+
+        content = """This url should be made into a link: http://example.com/somewhere/outthere and so should www.example.com/asdf.html?id=5&view=dashboard#report."""
+        expected = """This url should be made into a link: [http://example.com/somewhere/outthere](http://example.com/somewhere/outthere) and so should [www.example.com/asdf.html?id=5&view=dashboard#report](http://www.example.com/asdf.html?id=5&view=dashboard#report)."""
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
+
+        self.maxDiff = None
+        # Tests https://git.door43.org/Door43/en_ta/raw/master/translate/translate-source-text/01.md
+        content = """
+### Factors to Consider for a Source Text
+
+When choosing a source text, there are a number of factors that must be considered:
+
+  * **[Statement of Faith](../../intro/statement-of-faith/01.md)** - Is the text in line with the Statement of Faith?
+  * **[Translation Guidelines](../../intro/translation-guidelines/01.md)** - Is the text in line with the Translation Guidelines?
+  * **Language** - Is the text in a suitable language that translators and checkers understand well?
+  * **[Copyrights, Licensing, and Source Texts](../translate-source-licensing/01.md)** - Is the text released under a license that gives sufficient legal freedom?
+  * **[Source Texts and Version Numbers](../translate-source-version/01.md)** - Is the text the latest, most updated version?
+  * **[The Original and Source Languages](../translate-original/01.md)** - Does the translation team understand the difference between source languages and original languages?
+  * **[Original Manuscripts](../translate-manuscripts/01.md)** - Does the translation team understand about Original Manuscripts and [Textual Variants](../translate-textvariants/01.md)?
+
+It is important the the leaders of the churches in the language group agree that the source text is a good one. The Open Bible Stories are available in many source languages on http://ufw.io/stories/. There are also translations of the Bible there to be used as sources for translation in English, and soon other languages, as well.
+"""
+        expected = """
+### Factors to Consider for a Source Text
+
+When choosing a source text, there are a number of factors that must be considered:
+
+  * **[Statement of Faith](intro.html#statement-of-faith)** - Is the text in line with the Statement of Faith?
+  * **[Translation Guidelines](intro.html#translation-guidelines)** - Is the text in line with the Translation Guidelines?
+  * **Language** - Is the text in a suitable language that translators and checkers understand well?
+  * **[Copyrights, Licensing, and Source Texts](#translate-source-licensing)** - Is the text released under a license that gives sufficient legal freedom?
+  * **[Source Texts and Version Numbers](#translate-source-version)** - Is the text the latest, most updated version?
+  * **[The Original and Source Languages](#translate-original)** - Does the translation team understand the difference between source languages and original languages?
+  * **[Original Manuscripts](#translate-manuscripts)** - Does the translation team understand about Original Manuscripts and [Textual Variants](#translate-textvariants)?
+
+It is important the the leaders of the churches in the language group agree that the source text is a good one. The Open Bible Stories are available in many source languages on [http://ufw.io/stories/](http://ufw.io/stories/). There are also translations of the Bible there to be used as sources for translation in English, and soon other languages, as well.
+"""
+        converted = TaPreprocessor.fix_links(content)
+        self.assertEqual(converted, expected)
 
     @classmethod
     def extractFiles(self, file_name, repo_name):


### PR DESCRIPTION
Goal is to fix links like in the following tA file after the markdown is compiled into each manual's markdown file: https://git.door43.org/Door43/en_ta/raw/master/translate/translate-source-text/01.md

Here is that section rendered on test:
http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/Door43/en_ta/1288d00dd9/translate.html#translate-source-text