### PR TITLE
Updates tA preprocessor to include toc.yaml and config.yaml

### DIFF
--- a/client/preprocessors.py
+++ b/client/preprocessors.py
@@ -226,7 +226,7 @@ class TaPreprocessor(Preprocessor):
     def __init__(self, *args, **kwargs):
         super(TaPreprocessor, self).__init__(*args, **kwargs)
 
-    def get_title(self, project, link):
+    def get_title(self, project, link, default=None):
         proj = None
         if link in project.config():
             proj = project
@@ -238,7 +238,10 @@ class TaPreprocessor(Preprocessor):
             title_file = os.path.join(self.source_dir, proj.path, link, 'title.md')
             if os.path.isfile(title_file):
                 return read_file(title_file)
-        return link.replace('-', ' ').title()
+        if default:
+            return default
+        else:
+            return link.replace('-', ' ').title()
 
     def get_ref(self, project, link):
         if link in project.config():
@@ -268,7 +271,8 @@ class TaPreprocessor(Preprocessor):
         :return: 
         """
         if 'link' in section:
-            markdown = '{0} <a name="{1}"/>{2}\n\n'.format('#'*level, section['link'], section['title'])
+            markdown = '{0} <a name="{1}"/>{2}\n\n'.format('#'*level, section['link'], 
+                                                           self.get_title(project, section['link'], section['title']))
         else:
             markdown = '{0} {1}\n\n'.format('#'*level, section['title'])
         if 'link' in section:
@@ -312,6 +316,15 @@ class TaPreprocessor(Preprocessor):
             markdown = self.fix_links(markdown)
             output_file = os.path.join(self.output_dir, '{0}.md'.format(project.identifier))
             write_file(output_file, markdown)
+
+            # Copy the toc and config.yaml file to the output dir so they can be used to
+            # generate the ToC on live.door43.org
+            toc_file = os.path.join(self.source_dir, project.path, 'toc.yaml')
+            if os.path.isfile(toc_file):
+                copy(toc_file, os.path.join(self.output_dir, '{0}-toc.yaml'.format(project.identifier)))
+            config_file = os.path.join(self.source_dir, project.path, 'config.yaml')
+            if os.path.isfile(config_file):
+                copy(config_file, os.path.join(self.output_dir, '{0}-config.yaml'.format(project.identifier)))
         return True
 
     @staticmethod

--- a/tests/client_tests/test_ta_preprocessor.py
+++ b/tests/client_tests/test_ta_preprocessor.py
@@ -53,6 +53,11 @@ class TestTaPreprocessor(unittest.TestCase):
         self.assertTrue('../' not in intro)
         self.assertTrue('../' not in process)
         self.assertTrue('../' not in translate)
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'checking-toc.yaml')))
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'checking-config.yaml')))
+        preprocessor = TaPreprocessor(rc, repo_dir, self.out_dir)
+        self.assertEqual(preprocessor.get_title(rc.project('checking'), 'fake-link', 'My Title'), 'My Title')
+        self.assertEqual(preprocessor.get_title(rc.project('checking'), 'fake-link'), 'Fake Link')
 
     def test_fix_links(self):
         content = "This has [links](../section1/01.md) to the same [manual](../section2/01.md)"


### PR DESCRIPTION
Two things I forgot to do in the tA processor, so making an update:
 
1) I should be using the title.txt file for the header of the section, rather than what is in the toc.yaml file.  This may be different due to a shorter name in the ToC

2) Needed to include the toc.yaml and config.yaml for each project, prefixing them with the project identifier so that they can be used on the door43.org project pages to generate the ToC