### PR TITLE
Issue 556/fix timeout waiting for job to start.

### DIFF
--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -900,22 +900,21 @@ class TestConversions(TestCase):
 
         polling_timeout = 5 * 60  # poll for up to 5 minutes for job to complete or error
         sleep_interval = 5  # how often to check for completion
-        start_max_wait_count = polling_timeout / sleep_interval  # maximum count to wait for conversion to start (sec/interval)
-        for i in range(0, start_max_wait_count):
+        start = time.time()
+        end = start + polling_timeout
+        while time.time() < end:
+            time.sleep(sleep_interval)
             job = tx_manager.get_job(job_id)
             self.assertIsNotNone(job)
-            print("job status at " + str(i*sleep_interval) + ":\n" + str(job.log))
+            elapsed_seconds = int(time.time() - start)
+            print("job " + job_id + " status at " + str(elapsed_seconds) + ":\n" + str(job.log))
 
             if job.ended_at is not None:
                 success = True
                 break
 
-            if (i > start_max_wait_count) and (job.started_at is None):
-                success = False
-                self.warn("Timeout Waiting for start on job: " + job_id)
-                break
-
-            time.sleep(sleep_interval)  # delay before polling again
+        if not success:
+            self.warn("Timeout Waiting for start on job: " + job_id)
 
         return success, job
 

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -880,7 +880,7 @@ class TestConversions(TestCase):
             for build_log in build_logs:  # check for completion of each part
                 job_id = build_log['job_id']
                 if job_id not in finished:
-                    self.warn("Conversion Failed to start on job: " + job_id)
+                    self.warn("Timeout watiting for start on job: " + job_id)
 
         return done, job
 
@@ -900,11 +900,11 @@ class TestConversions(TestCase):
 
         polling_timeout = 5 * 60  # poll for up to 5 minutes for job to complete or error
         sleep_interval = 5  # how often to check for completion
-        start_max_wait_count = 30 / sleep_interval  # maximum count to wait for conversion to start (sec/interval)
-        for i in range(0, polling_timeout / sleep_interval):
+        start_max_wait_count = polling_timeout / sleep_interval  # maximum count to wait for conversion to start (sec/interval)
+        for i in range(0, start_max_wait_count):
             job = tx_manager.get_job(job_id)
             self.assertIsNotNone(job)
-            print("job status at " + str(i) + ":\n" + str(job.log))
+            print("job status at " + str(i*sleep_interval) + ":\n" + str(job.log))
 
             if job.ended_at is not None:
                 success = True
@@ -912,7 +912,7 @@ class TestConversions(TestCase):
 
             if (i > start_max_wait_count) and (job.started_at is None):
                 success = False
-                self.warn("Conversion Failed to start on job: " + job_id)
+                self.warn("Timeout Waiting for start on job: " + job_id)
                 break
 
             time.sleep(sleep_interval)  # delay before polling again

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -633,8 +633,8 @@ class TestConversions(TestCase):
         print(message)
 
     def print_file(self, file_name, file_path):
-        text = file_utils.read_file(file_path)
-        print("Output file (" + file_name + "): " + text)
+        text = file_utils.read_file(file_path)[:200]  # get the start of the file
+        print("\nOutput file (" + file_name + "): " + text + "\n")
 
     def check_deployed_files(self, handler, expected_output_files, extension, key, chapter_count=-1):
         check_list = []
@@ -699,7 +699,7 @@ class TestConversions(TestCase):
                     self.warn("timeout getting file: " + path)
                     break
 
-                print("retry fetch of: " + path)
+                # print("retry fetch of: " + path)
                 output = handler.get_file_contents(path)
 
             self.assertIsNotNone(output, "missing file: " + path)


### PR DESCRIPTION
TestConversions - fixed logic error which caused timeout at 30 seconds waiting for job to start.  It should be 5 minutes.  Also changed verbiage to reflect that it is a timeout in waiting.