### PR TITLE
Improve coverage for models

### DIFF
--- a/libraries/models/job.py
+++ b/libraries/models/job.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, print_function
-from six import string_types
 from libraries.models.model import Model
 
 
@@ -42,7 +41,7 @@ class TxJob(Model):
         'errors': [],
     }
 
-    def __init__(self, data=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         # Init attributes
         self.job_id = None
         self.user = None
@@ -70,16 +69,7 @@ class TxJob(Model):
         self.log = []
         self.warnings = []
         self.errors = []
-
-        super(TxJob, self).__init__(**kwargs)
-
-        if isinstance(data, dict):
-            self.populate(data)
-            if self.db_handler and len(data) == 1 and 'job_id' in data:
-                self.load()
-        elif isinstance(data, string_types):
-            if self.db_handler:
-                self.load({'job_id': data})
+        super(TxJob, self).__init__(*args, **kwargs)
 
     def log_message(self, message):
         self.log.append(message)

--- a/libraries/models/manifest.py
+++ b/libraries/models/manifest.py
@@ -25,7 +25,7 @@ class TxManifest(Model):
         'manifest': {},
     }
 
-    def __init__(self, data=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         # Init attributes
         self.repo_name = None
         self.user_name = None
@@ -36,10 +36,4 @@ class TxManifest(Model):
         self.views = 0
         self.last_updated = None
         self.manifest = {}
-
-        super(TxManifest, self).__init__(**kwargs)
-
-        if isinstance(data, dict):
-            self.populate(data)
-            if self.db_handler and len(data) == 2 and 'repo_name' in data and 'user_name' in data:
-                self.load()
+        super(TxManifest, self).__init__(*args, **kwargs)

--- a/libraries/models/module.py
+++ b/libraries/models/module.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, print_function
-from six import string_types
 from libraries.models.model import Model
 
 
@@ -29,7 +28,7 @@ class TxModule(Model):
         'version': 1,
     }
 
-    def __init__(self, data=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Init attributes"""
         self.name = None
         self.input_format = None
@@ -40,13 +39,4 @@ class TxModule(Model):
         self.resource_types = []
         self.type = None
         self.version = 1
-
-        super(TxModule, self).__init__(**kwargs)
-
-        if isinstance(data, dict):
-            self.populate(data)
-            if self.db_handler and len(data) == 1 and 'name' in data:
-                self.load()
-        elif isinstance(data, string_types):
-            if self.db_handler:
-                self.load({'name': data})
+        super(TxModule, self).__init__(*args, **kwargs)

--- a/tests/client_tests/test_ta_preprocessor.py
+++ b/tests/client_tests/test_ta_preprocessor.py
@@ -88,8 +88,6 @@ class TestTaPreprocessor(unittest.TestCase):
         expected = """This url should be made into a link: [http://example.com/somewhere/outthere](http://example.com/somewhere/outthere) and so should [www.example.com/asdf.html?id=5&view=dashboard#report](http://www.example.com/asdf.html?id=5&view=dashboard#report)."""
         converted = TaPreprocessor.fix_links(content)
         self.assertEqual(converted, expected)
-
-        self.maxDiff = None
         # Tests https://git.door43.org/Door43/en_ta/raw/master/translate/translate-source-text/01.md
         content = """
 ### Factors to Consider for a Source Text

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -21,8 +21,7 @@ class ManagerTest(unittest.TestCase):
     MOCK_MODULE_TABLE_NAME = 'mock-module'
 
     mock_gogs = None
-    setup_tables = False
-    
+
     tx_manager_env_vars = {
         'api_url': MOCK_API_URL,
         'cdn_url': MOCK_CDN_URL,
@@ -49,15 +48,21 @@ class ManagerTest(unittest.TestCase):
         self.tx_manager = TxManager(**self.tx_manager_env_vars)
         ManagerTest.mock_gogs.reset_mock()
         ManagerTest.requested_urls = []
-        if not ManagerTest.setup_tables:
-            self.init_tables()
-            ManagerTest.setup_tables = True
+        self.init_tables()
         self.job_items = {}
         self.module_items = {}
         self.init_items()
         self.populate_tables()
 
     def init_tables(self):
+        try:
+            self.tx_manager.job_db_handler.table.delete()
+        except:
+            pass
+        try:
+            self.tx_manager.module_db_handler.table.delete()
+        except:
+            pass
         self.tx_manager.job_db_handler.resource.create_table(
             TableName=ManagerTest.MOCK_JOB_TABLE_NAME,
             KeySchema=[

--- a/tests/models_tests/test_model.py
+++ b/tests/models_tests/test_model.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals, print_function
 import unittest
+from moto import mock_dynamodb2
 from libraries.models.module import Model
+from libraries.aws_tools.dynamodb_handler import DynamoDBHandler
 
 
 class MyModel(Model):
@@ -13,13 +15,63 @@ class MyModel(Model):
         'field2'
     ]
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.field1 = None
         self.field2 = None
-        super(MyModel, self).__init__()
+        super(MyModel, self).__init__(*args, **kwargs)
 
 
+@mock_dynamodb2
 class ModelTests(unittest.TestCase):
+    TABLE_NAME = 'my-module-table'
+
+    def setUp(self):
+        self.db_handler = DynamoDBHandler(ModelTests.TABLE_NAME)
+        self.init_table()
+        self.items = {}
+        self.init_items()
+        self.populate_table()
+
+    def init_table(self):
+        try:
+            self.db_handler.table.delete()
+        except:
+            pass
+        self.db_handler.resource.create_table(
+            TableName=ModelTests.TABLE_NAME,
+            KeySchema=[
+                {
+                    'AttributeName': 'field1',
+                    'KeyType': 'HASH'
+                },
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'field1',
+                    'AttributeType': 'S'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5
+            },
+        )
+
+    def init_items(self):
+        self.items = {
+            'mymodel1': {
+                'field1': 'mymodel1',
+                'field2': 'something',
+            },
+            'mymodel2': {
+                'field1': 'mymodel2',
+                'field2': 'something else',
+            },
+        }
+
+    def populate_table(self):
+        for idx in self.items:
+            MyModel(db_handler=self.db_handler).insert(self.items[idx])
 
     def test_populate(self):
         """Test populate method."""
@@ -33,6 +85,46 @@ class ModelTests(unittest.TestCase):
         self.assertTrue(hasattr(obj, 'field1'))
         self.assertEqual(obj.field2, 'value2')
         self.assertFalse(hasattr(obj, 'field3'))
+        
+    def test_query(self):
+        models = MyModel(db_handler=self.db_handler).query()
+        self.assertEqual(len(models), len(self.items))
+        for model in models:
+            self.assertEqual(model.get_db_data(), MyModel(self.items[model.field1]).get_db_data())
+
+    def test_load(self):
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel2'})
+        self.assertEqual(model.get_db_data(), MyModel(self.items['mymodel2']).get_db_data())
+
+    def test_insert(self):
+        # Insert by giving fields in the constructor
+        MyModel({'field1': 'mymodel3', 'field2': 'something good'}, db_handler=self.db_handler).insert()
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel3'})
+        self.assertEqual(model.field2, 'something good')
+        # Insert by giving data to the insert() method
+        MyModel(db_handler=self.db_handler).insert({'field1': 'mymodel4', 'field2': 'something better'})
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel4'})
+        self.assertEqual(model.field2, 'something better')
+
+    def test_update(self):
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel1'})
+
+        # Update by setting fields and calling update()
+        model.field2 = 'change'
+        model.update()
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel1'})
+        self.assertEqual(model.field2, 'change')
+
+        # Update by giving a dict to update()
+        model.update({'field1': 'cannot change', 'field2': 'can change'})
+        self.assertEqual(model.field1, 'mymodel1')  # didn't change
+        model = MyModel(db_handler=self.db_handler).load({'field1': 'mymodel1'})
+        self.assertEqual(model.field2, 'can change')
+
+    def test_delete_model(self):
+        MyModel('model2', db_handler=self.db_handler).delete()
+        model = MyModel('model2', db_handler=self.db_handler)
+        self.assertIsNone(model.field1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Handles testing better for the main Model class to for better coverage.

The data payload is also now handled all by the model.py file and not the individual model subclasses.

I found that the whole table needed to be deleted for each test case otherwise things like counting the number of items in the table might be wrong if another test inserted to the table. So now I just try to delete the table (catch exception if fails) and create the table again.