### PR TITLE
Fixes #583 - Fixes links to manuals by adding the index of the manual

### DIFF
--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -346,14 +346,16 @@ class TaPreprocessor(Preprocessor):
                 copy(config_file, os.path.join(self.output_dir, '{0}-{1}-config.yaml'.format(str(idx+1).zfill(2), project.identifier)))
         return True
 
-    @staticmethod
-    def fix_links(content):
+    def fix_links(self, content):
         # fix links to other sections within the same manual (only one ../ and a section name)
         # e.g. [Section 2](../section2/01.md) => [Section 2](#section2)
         content = re.sub(r'\]\(\.\./([^/\)]+)/01.md\)', r'](#\1)', content)
         # fix links to other manuals (two ../ and a manual name and a section name)
         # e.g. [how to translate](../../translate/accurate/01.md) => [how to translate](translate.html#accurate)
-        content = re.sub(r'\]\(\.\./\.\./([^/\)]+)/([^/\)]+)/01.md\)', r'](\1.html#\2)', content)
+        for idx, project in enumerate(self.rc.projects):
+            pattern = re.compile(r'\]\(\.\./\.\./{0}/([^/\)]+)/01.md\)'.format(project.identifier))
+            replace = r']({0}-{1}.html#\1)'.format(str(idx+1).zfill(2), project.identifier)
+            content = re.sub(pattern, replace, content)
         # fix links to other sections that just have the section name but no 01.md page (preserve http:// links)
         # e.g. See [Verbs](figs-verb) => See [Verbs](#figs-verb)
         content = re.sub(r'\]\(([^# :/\)]+)\)', r'](#\1)', content)

--- a/tests/client_tests/resources/manifests/ta/manifest.yaml
+++ b/tests/client_tests/resources/manifests/ta/manifest.yaml
@@ -1,0 +1,68 @@
+---
+
+dublin_core:
+    conformsto: 'rc0.2'
+    contributor:
+        - 'unfoldingWord'
+        - 'Wycliffe Associates'
+    creator: 'Wycliffe Associates'
+    description: ''
+    format: 'text/markdown'
+    identifier: 'ta'
+    issued: '2016-04-19'
+    language:
+        identifier: 'en'
+        title: 'English'
+        direction: 'ltr'
+    modified: '2017-04-13'
+    publisher: 'Door43'
+    relation:
+    rights: 'CC BY-SA 4.0'
+    source:
+        -
+            identifier: 'ta'
+            language: 'en'
+            version: 'pre6'
+    subject: ''
+    title: 'translationAcademy'
+    type: 'man'
+    version: '6'
+
+checking:
+    checking_entity:
+        - 'Wycliffe Associates'
+    checking_level: '3'
+
+projects:
+    -
+        categories:
+            - 'ta'
+        identifier: 'intro'
+        path: './intro'
+        sort: 0
+        title: 'Introduction to translationAcademy'
+        versification:
+    -
+        categories:
+            - 'ta'
+        identifier: 'process'
+        path: './process'
+        sort: 1
+        title: 'Process Manual'
+        versification:
+    -
+        categories:
+            - 'ta'
+        identifier: 'translate'
+        path: './translate'
+        sort: 2
+        title: 'Translation Manual'
+        versification:
+    -
+        categories:
+            - 'ta'
+        identifier: 'checking'
+        path: './checking'
+        sort: 3
+        title: 'Checking Manual'
+        versification:


### PR DESCRIPTION
For linking to other manuals, also had to insert the index of the manual in the URL, Loops through the projects and replaces each link with the `0#-<project>` identifier.