### PR TITLE
Changes italics to just the dependencies and recommendations

### DIFF
--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -305,7 +305,7 @@ class TaPreprocessor(Preprocessor):
                 if 'dependencies' in config[link] and config[link]['dependencies']:
                     top_box += 'In order to understand this topic, it would be good to read:\n\n'
                     for dependency in config[link]['dependencies']:
-                        top_box += '  * *[{0}]({1}*)\n'.\
+                        top_box += '  * *[{0}]({1})*\n'.\
                             format(self.get_title(project, dependency), self.get_ref(project, dependency))
                 if 'recommended' in config[link] and config[link]['recommended']:
                     bottom_box += 'Next we recommend you learn about:\n\n'

--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -299,18 +299,18 @@ class TaPreprocessor(Preprocessor):
             bottom_box = ""
             question = self.get_question(project, link)
             if question:
-                top_box += '*This page answers the question: {0}*\n\n'.format(question)
+                top_box += 'This page answers the question: *{0}*\n\n'.format(question)
             config = project.config()
             if link in config:
                 if 'dependencies' in config[link] and config[link]['dependencies']:
-                    top_box += '*In order to understand this topic, it would be good to read:*\n\n'
+                    top_box += 'In order to understand this topic, it would be good to read:\n\n'
                     for dependency in config[link]['dependencies']:
-                        top_box += '  * [{0}]({1})\n'.\
+                        top_box += '  * *[{0}]({1}*)\n'.\
                             format(self.get_title(project, dependency), self.get_ref(project, dependency))
                 if 'recommended' in config[link] and config[link]['recommended']:
-                    bottom_box += '*Next we recommend you learn about:*\n\n'
+                    bottom_box += 'Next we recommend you learn about:\n\n'
                     for recommended in config[link]['recommended']:
-                        bottom_box += '  * [{0}]({1})\n'.\
+                        bottom_box += '  * *[{0}]({1})*\n'.\
                             format(self.get_title(project, recommended), self.get_ref(project, recommended))
             if top_box:
                 markdown += '<div class="top-box box" markdown="1">\n{0}\n</div>\n\n'.format(top_box)


### PR DESCRIPTION
Needed to switch the italics in the markdown for the tA to have the items in Dependencies and Recommendation list to be italic, not the header for it. Also makes just the question being answered italic, not the text before it.