### PR TITLE
Feature - Issue 573 - properly convert rc links for ta

### DIFF
--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -351,6 +351,9 @@ class TaPreprocessor(Preprocessor):
         return True
 
     def fix_links(self, content):
+        # convert RC links, e.g.
+        content = re.sub(r'rc://([^/]+)/([^/]+)/([^/]+)/([^\s\p\)\]\n$]+)',
+                         r'https://git.door43.org/Door43/\1_\2/src/master/\4.md', content, flags=re.IGNORECASE)
         # fix links to other sections within the same manual (only one ../ and a section name)
         # e.g. [Section 2](../section2/01.md) => [Section 2](#section2)
         content = re.sub(r'\]\(\.\./([^/\)]+)/01.md\)', r'](#\1)', content)
@@ -364,7 +367,9 @@ class TaPreprocessor(Preprocessor):
         # e.g. See [Verbs](figs-verb) => See [Verbs](#figs-verb)
         content = re.sub(r'\]\(([^# :/\)]+)\)', r'](#\1)', content)
         # convert URLs to links if not already
-        content = re.sub(r'([^"\(])((http|https|ftp)://[A-Z0-9\/\?&_\.:=#-]+[A-Z0-9\/\?&_:=#-])', r'\1[\2](\2)', content, flags=re.IGNORECASE)
+        content = re.sub(r'([^"\(])((http|https|ftp)://[A-Z0-9\/\?&_\.:=#-]+[A-Z0-9\/\?&_:=#-])', r'\1[\2](\2)',
+                         content, flags=re.IGNORECASE)
         # URLS wth just www at the start, no http
-        content = re.sub(r'([^A-Z0-9"\(\/])(www\.[A-Z0-9\/\?&_\.:=#-]+[A-Z0-9\/\?&_:=#-])', r'\1[\2](http://\2)', content, flags=re.IGNORECASE)
+        content = re.sub(r'([^A-Z0-9"\(\/])(www\.[A-Z0-9\/\?&_\.:=#-]+[A-Z0-9\/\?&_:=#-])', r'\1[\2](http://\2)',
+                         content, flags=re.IGNORECASE)
         return content

--- a/libraries/client/preprocessors.py
+++ b/libraries/client/preprocessors.py
@@ -351,7 +351,7 @@ class TaPreprocessor(Preprocessor):
         return True
 
     def fix_links(self, content):
-        # convert RC links, e.g.
+        # convert RC links, e.g. rc://en/tn/help/1sa/16/02 => https://git.door43.org/Door43/en_tn/1sa/16/02.md
         content = re.sub(r'rc://([^/]+)/([^/]+)/([^/]+)/([^\s\p\)\]\n$]+)',
                          r'https://git.door43.org/Door43/\1_\2/src/master/\4.md', content, flags=re.IGNORECASE)
         # fix links to other sections within the same manual (only one ../ and a section name)

--- a/tests/client_tests/test_ta_preprocessor.py
+++ b/tests/client_tests/test_ta_preprocessor.py
@@ -87,9 +87,9 @@ class TestTaPreprocessor(unittest.TestCase):
         self.assertEqual(converted, expected)
 
         content = """This [link](rc://en/tw/dict/bible/other/dream) is a rc link that should go to 
-            other/dream/01.md in the en_tw repo"""
-        expected = """This [link](https://git.door43.org/Door43/en_tw/src/master/bible/other/dream/01.md) is a rc link that should go to 
-            other/dream/01.md in the en_tw repo"""
+            other/dream.md in the en_tw repo"""
+        expected = """This [link](https://git.door43.org/Door43/en_tw/src/master/bible/other/dream.md) is a rc link that should go to 
+            other/dream.md in the en_tw repo"""
         converted = ta.fix_links(content)
         self.assertEqual(converted, expected)
 

--- a/tests/client_tests/test_ta_preprocessor.py
+++ b/tests/client_tests/test_ta_preprocessor.py
@@ -86,6 +86,13 @@ class TestTaPreprocessor(unittest.TestCase):
         converted = ta.fix_links(content)
         self.assertEqual(converted, expected)
 
+        content = """This [link](rc://en/tw/dict/bible/other/dream) is a rc link that should go to 
+            other/dream/01.md in the en_tw repo"""
+        expected = """This [link](https://git.door43.org/Door43/en_tw/src/master/bible/other/dream/01.md) is a rc link that should go to 
+            other/dream/01.md in the en_tw repo"""
+        converted = ta.fix_links(content)
+        self.assertEqual(converted, expected)
+
         content = """This url should be made into a link: http://example.com/somewhere/outthere and so should www.example.com/asdf.html?id=5&view=dashboard#report."""
         expected = """This url should be made into a link: [http://example.com/somewhere/outthere](http://example.com/somewhere/outthere) and so should [www.example.com/asdf.html?id=5&view=dashboard#report](http://www.example.com/asdf.html?id=5&view=dashboard#report)."""
         converted = ta.fix_links(content)


### PR DESCRIPTION
Somehow this never got in as a PR a few weeks ago. Adds support for rc:// links in tA to be converted.