### PR TITLE
Makes it so data we show in the logs doesn't have sensitive info

### DIFF
--- a/libraries/lambda_handlers/handler.py
+++ b/libraries/lambda_handlers/handler.py
@@ -22,7 +22,7 @@ class Handler(object):
             App(**event['vars'])
 
         App.logger.debug("EVENT:")
-        App.logger.debug(json.dumps(self.mask_event(self.event)))
+        App.logger.debug(json.dumps(self.mask_event(event)))
 
         self.data = {}
         if 'data' in event and isinstance(event['data'], dict):

--- a/libraries/lambda_handlers/handler.py
+++ b/libraries/lambda_handlers/handler.py
@@ -74,6 +74,8 @@ class Handler(object):
 
     @classmethod
     def mask_event(cls, event):
+        if not event or not isinstance(event, dict):
+            return event
         masked_event = copy.deepcopy(event)
         if 'vars' in masked_event:
             if 'db_pass' in masked_event['vars'] and masked_event['vars']['db_pass']:

--- a/tests/handler_tests/test_handler.py
+++ b/tests/handler_tests/test_handler.py
@@ -50,7 +50,8 @@ class TestHandlers(TestCase):
                 'key2': 'value2'
             },
             'vars': {
-                'cdn_bucket': 'test-cdn-bucket'
+                'cdn_bucket': 'test-cdn-bucket',
+                'db_pass': 'mypassword'
             }
         }
         context = {
@@ -66,3 +67,27 @@ class TestHandlers(TestCase):
             handler.handle(event, None)
         except Exception as e:
             self.assertEqual(e.message, 'Bad Request: integer division or modulo by zero')
+
+    def test_mask_event(self):
+        event = {
+            'data': {
+                'key1': 'value1',
+                'gogs_user_token': 'gogstoken'
+            },
+            'vars': {
+                'cdn_bucket': 'test-cdn-bucket',
+                'db_pass': 'mypassword',
+                'gogs_user_token': 'gogstoken'
+            }
+        }
+        masked = Handler.mask_event(event)
+        # Make sure event wasn't touched
+        self.assertNotEqual(masked['vars']['db_pass'], event['vars']['db_pass'])
+        self.assertNotEqual(masked['vars']['gogs_user_token'], event['vars']['gogs_user_token'])
+        self.assertNotEqual(masked['data']['gogs_user_token'], event['data']['gogs_user_token'])
+        # Make sure masked_event has been masked
+        self.assertEqual(masked['vars']['db_pass'], 'my********')
+        self.assertEqual(masked['vars']['gogs_user_token'], 'go*******')
+        self.assertEqual(masked['data']['gogs_user_token'], 'go*******')
+        # Make sure other values are not masked
+        self.assertEqual(masked['data']['key1'], 'value1')

--- a/tests/handler_tests/test_handler.py
+++ b/tests/handler_tests/test_handler.py
@@ -91,3 +91,5 @@ class TestHandlers(TestCase):
         self.assertEqual(masked['data']['gogs_user_token'], 'go*******')
         # Make sure other values are not masked
         self.assertEqual(masked['data']['key1'], 'value1')
+        self.assertIsNone(Handler.mask_event(None))
+        self.assertTrue(Handler.mask_event(True))


### PR DESCRIPTION
Adds masking to how we show the event payload in the logs. Shows first two characters of the db_pass and gogs_user_token just so we can know which one was used.
