### PR TITLE
Fix 744/dokuwik conversions still have wrong language code in manifest table

### DIFF
--- a/libraries/client/client_webhook.py
+++ b/libraries/client/client_webhook.py
@@ -83,6 +83,7 @@ class ClientWebhook(object):
             for key, value in manifest_data.iteritems():
                 setattr(tx_manifest, key, value)
             App.logger.debug('Updating manifest in manifest table: {0}'.format(manifest_data))
+            tx_manifest.update()
         else:
             tx_manifest = TxManifest(**manifest_data)
             App.logger.debug('Inserting manifest into manifest table: {0}'.format(tx_manifest))


### PR DESCRIPTION
Issue: https://github.com/unfoldingWord-dev/door43.org/issues/744

Updated data in manifests, but discovered that manifest table was not being updated in manifest table on new conversion.  Added a call to update and a unit test to verify.