### PR TITLE
Fix unit test

### DIFF
--- a/test-setup.py
+++ b/test-setup.py
@@ -59,7 +59,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     install_requires=[
-        'requests==2.13.0',
+        'requests>=2.13.0',
         'responses==0.5.1',
         'boto3==1.4.4',
         'bs4==0.0.1',

--- a/tests/client_tests/test_client_webhook.py
+++ b/tests/client_tests/test_client_webhook.py
@@ -288,10 +288,9 @@ class ClientWebhookTest(unittest.TestCase):
         return self.upload_file(bucket_name, project_file, s3_key)
 
     def upload_file(self, bucket_name, project_file, s3_key):
-        filename = tempfile.mktemp(dir=ClientWebhookTest.base_temp_dir)
-        shutil.copyfile(project_file, filename)
-        self.uploaded_files.append({'file': filename, 'key': bucket_name + '/' + s3_key})
-        return
+        with tempfile.NamedTemporaryFile(dir=ClientWebhookTest.base_temp_dir, delete=False) as tmp:
+            shutil.copyfile(project_file, tmp.name)
+            self.uploaded_files.append({'file': tmp.name, 'key': bucket_name + '/' + s3_key})
 
     def mock_cdn_get_json(self, project_json_key):
         return {}


### PR DESCRIPTION
[tempfile.mktemp](https://docs.python.org/2/library/tempfile.html#tempfile.mktemp) does not actually create a file, so we would hit an error for trying to copy to a non-existent file.

e.g. (from https://travis-ci.org/unfoldingWord-dev/tx-manager/builds/343357743)
```
  File "/home/travis/build/unfoldingWord-dev/tx-manager/libraries/converters/converter.py", line 91, in run
    self.upload_archive()
  File "/home/travis/build/unfoldingWord-dev/tx-manager/libraries/converters/converter.py", line 131, in upload_archive
    App.cdn_s3_handler().upload_file(self.output_zip_file, self.cdn_file, cache_time=0)
  File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/moto/core/models.py", line 70, in wrapper
    result = func(*args, **kwargs)
  File "/home/travis/build/unfoldingWord-dev/tx-manager/tests/client_tests/test_client_webhook.py", line 284, in mock_cdn_upload_file
    return self.upload_file(bucket_name, project_file, s3_key)
  File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/moto/core/models.py", line 70, in wrapper
    result = func(*args, **kwargs)
  File "/home/travis/build/unfoldingWord-dev/tx-manager/tests/client_tests/test_client_webhook.py", line 292, in upload_file
    shutil.copyfile(project_file, filename)
  File "/opt/python/2.7.13/lib/python2.7/shutil.py", line 83, in copyfile
    with open(dst, 'wb') as fdst:
IOError: [Errno 2] No such file or directory: u'/tmp/test-tx-manager/tmp5QoEYZ'
```

