### PR TITLE
Fixed travis install of apex

### DIFF
--- a/scripts/travis_install_apex.sh
+++ b/scripts/travis_install_apex.sh
@@ -7,10 +7,11 @@ LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep -Eo '"name":
 if [ -z $LATEST ]; then
     LATEST=v0.15.0
 fi
-URL="https://github.com/apex/apex/releases/download/${LATEST}/apex_linux_amd64"
-DEST="${PARENT_DIR}/apex"
+URL="https://github.com/apex/apex/releases/download/${LATEST}/apex_${LATEST#v}_linux_amd64.tar.gz"
 
-curl -sL ${URL} -o ${DEST}
-chmod +x ${DEST}
+cd ${PARENT_DIR}
+curl -sL ${URL} -o apex.tar.gz
+tar -xzf apex.tar.gz
+chmod +x apex
 
 echo "Installed apex ${LATEST}"


### PR DESCRIPTION
Apex changed their release naming format and changed their downloads to
tarred gzipped files intead of direct binaries.